### PR TITLE
skinny-micro's before/after in filter apps don't effect unmatched routes

### DIFF
--- a/micro/src/test/scala/example/BeforeAfterFilterSpec.scala
+++ b/micro/src/test/scala/example/BeforeAfterFilterSpec.scala
@@ -1,0 +1,43 @@
+package example
+
+import skinny.micro._
+import org.scalatra.test.scalatest._
+
+// skinny-micro's before/after in filter apps don't effect unmatched routes
+class BeforeAfterFilterSpec extends ScalatraFlatSpec {
+
+  addFilter(new WebApp {
+    before() {
+      response.setHeader("x-first", "1")
+    }
+    get("/first") {
+      "first one"
+    }
+  }, "/*")
+
+  addFilter(new WebApp {
+    before() {
+      response.setHeader("x-second", "1")
+    }
+    get("/second") {
+      "second one"
+    }
+  }, "/*")
+
+  it should "not effect other web apps" in {
+    get("/first") {
+      status should equal(200)
+      body should equal("first one")
+      header.get("x-first") should equal(Some("1"))
+      header.get("x-second") should equal(None)
+    }
+
+    get("/second") {
+      status should equal(200)
+      body should equal("second one")
+      header.get("x-first") should equal(None)
+      header.get("x-second") should equal(Some("1"))
+    }
+  }
+
+}

--- a/micro/src/test/scala/org/scalatra/AfterFilterTest.scala
+++ b/micro/src/test/scala/org/scalatra/AfterFilterTest.scala
@@ -1,0 +1,59 @@
+package org.scalatra
+
+import org.scalatra.test.scalatest.ScalatraFunSuite
+import skinny.micro.SkinnyMicroFilter
+
+class AfterTestFilter extends SkinnyMicroFilter {
+
+  after() {
+    response.setStatus(204)
+  }
+
+  after("/filtered/some/path") {
+    response.setStatus(202)
+  }
+
+  after("/filtered/other/path") {
+    response.setStatus(206)
+  }
+
+  get("/filtered/some/path") {}
+
+  get("/filtered/other/path") {}
+
+  get("/filtered/third/path") {}
+
+}
+class YetAnotherFilter extends SkinnyMicroFilter {
+  get("/yet-another/path") {
+    response.setStatus(200)
+  }
+}
+
+class AfterFilterTest extends ScalatraFunSuite {
+
+  mount(classOf[AfterTestFilter], "/*")
+  mount(classOf[YetAnotherFilter], "/*")
+
+  test("afterAll is applied to all paths") {
+    get("/filtered/third/path") {
+      status should equal(204)
+    }
+  }
+
+  test("after only applies to a given path") {
+    get("/filtered/some/path") {
+      status should equal(202)
+    }
+    get("/filtered/other/path") {
+      status should equal(206)
+    }
+  }
+
+  test("after won't be applied to another servlets") {
+    get("/yet-another/path") {
+      status should equal(200)
+    }
+  }
+
+}

--- a/micro/src/test/scala/org/scalatra/AfterServletTest.scala
+++ b/micro/src/test/scala/org/scalatra/AfterServletTest.scala
@@ -1,14 +1,9 @@
 package org.scalatra
 
 import org.scalatra.test.scalatest.ScalatraFunSuite
-import skinny.micro.base.BeforeAfterDsl
-import skinny.micro.routing.RoutingDsl
 import skinny.micro.SkinnyMicroServlet
 
-class AfterTestServlet
-    extends SkinnyMicroServlet
-    with RoutingDsl
-    with BeforeAfterDsl {
+class AfterTestServlet extends SkinnyMicroServlet {
 
   after() {
     response.setStatus(204)
@@ -29,25 +24,34 @@ class AfterTestServlet
   get("/third/path") {}
 
 }
-
-class AfterServletTest extends AfterTest {
-  mount(classOf[AfterTestServlet], "/*")
+class YetAnotherServlet extends SkinnyMicroServlet {
+  get("/path") {
+    response.setStatus(200)
+  }
 }
 
-abstract class AfterTest extends ScalatraFunSuite {
+class AfterServletTest extends ScalatraFunSuite {
+  mount(classOf[AfterTestServlet], "/filtered/*")
+  mount(classOf[YetAnotherServlet], "/yet-another/*")
 
   test("afterAll is applied to all paths") {
-    get("/third/path") {
+    get("/filtered/third/path") {
       status should equal(204)
     }
   }
 
   test("after only applies to a given path") {
-    get("/some/path") {
+    get("/filtered/some/path") {
       status should equal(202)
     }
-    get("/other/path") {
+    get("/filtered/other/path") {
       status should equal(206)
+    }
+  }
+
+  test("after won't be applied to another servlets") {
+    get("/yet-another/path") {
+      status should equal(200)
     }
   }
 


### PR DESCRIPTION
This pull request introduces an incompatibility for existing Scalatra based applications. In Scalatra apps, both of the following before operations are applied.

```scala
// skinny-micro's before/after in filter apps don't effect unmatched routes
class BeforeAfterFilterSpec extends ScalatraFlatSpec {

  addFilter(new WebApp {
    before() {
      response.setHeader("x-first", "1")
    }
    get("/first") {
      "first one"
    }
  }, "/*")

  addFilter(new WebApp {
    before() {
      response.setHeader("x-second", "1")
    }
    get("/second") {
      "second one"
    }
  }, "/*")

  it should "not effect other web apps" in {
    get("/first") {
      status should equal(200)
      body should equal("first one")
      header.get("x-first") should equal(Some("1"))
      header.get("x-second") should equal(None)
    }

    get("/second") {
      status should equal(200)
      body should equal("second one")
      header.get("x-first") should equal(None)
      header.get("x-second") should equal(Some("1"))
    }
  }

}
```