### PR TITLE
Replace skinny-micro-json to new one based on only jackson-scala-module

### DIFF
--- a/micro-json4s/build.sbt
+++ b/micro-json4s/build.sbt
@@ -1,0 +1,1 @@
+scalariformSettings

--- a/micro-json4s/src/main/scala/skinny/json4s/AngularJSONStringOps.scala
+++ b/micro-json4s/src/main/scala/skinny/json4s/AngularJSONStringOps.scala
@@ -1,0 +1,19 @@
+package skinny.json4s
+
+/**
+ * JSON String operations for Angular application's server side.
+ *
+ * - camelCase keys
+ * - JSON vulnerability protection enabled by default
+ */
+trait AngularJSONStringOps extends JSONStringOps {
+
+  // JSON vulnerability protection enabled by default
+  override protected def useJSONVulnerabilityProtection: Boolean = true
+
+  // camelCase keys by default
+  override protected def useUnderscoreKeysForJSON: Boolean = false
+
+}
+
+object AngularJSONStringOps extends AngularJSONStringOps

--- a/micro-json4s/src/main/scala/skinny/json4s/JSONStringOps.scala
+++ b/micro-json4s/src/main/scala/skinny/json4s/JSONStringOps.scala
@@ -1,0 +1,190 @@
+package skinny.json4s
+
+import com.fasterxml.jackson.databind.{ DeserializationFeature, ObjectMapper, ObjectWriter }
+import org.json4s._
+import org.json4s.jackson.Json4sScalaModule
+
+import scala.util.control.Exception._
+
+/**
+ * Easy-to-use JSON String Operation.
+ */
+trait JSONStringOps extends {
+
+  /**
+   * Use the prefix for JSON Vulnerability Protection.
+   * see: "https://docs.angularjs.org/api/ng/service/$http"
+   */
+  protected def useJSONVulnerabilityProtection: Boolean = false
+
+  /**
+   * the prefix for JSON Vulnerability Protection.
+   * see: "https://docs.angularjs.org/api/ng/service/$http"
+   */
+  protected def prefixForJSONVulnerabilityProtection: String = ")]}',\n"
+
+  /**
+   * Default key policy.
+   */
+  protected def useUnderscoreKeysForJSON: Boolean = true
+
+  /**
+   * JSON format support implicitly.
+   */
+  protected implicit val jsonFormats: Formats = DefaultFormats ++ org.json4s.ext.JodaTimeSerializers.all
+
+  // -------------------------------
+  // Avoid extending org.json4s.jackson.JsonMethods due to #render method conflict
+  // -------------------------------
+
+  private[this] lazy val _defaultMapper = {
+    val m = new ObjectMapper()
+    m.registerModule(new Json4sScalaModule)
+    m
+  }
+  private[this] def mapper = _defaultMapper
+
+  def defaultObjectMapper: ObjectMapper = mapper
+
+  private[this] def parse(in: JsonInput, useBigDecimalForDouble: Boolean = false): JValue = {
+    mapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, useBigDecimalForDouble)
+    in match {
+      case StringInput(s) => mapper.readValue(s, classOf[JValue])
+      case ReaderInput(rdr) => mapper.readValue(rdr, classOf[JValue])
+      case StreamInput(stream) => mapper.readValue(stream, classOf[JValue])
+      case FileInput(file) => mapper.readValue(file, classOf[JValue])
+    }
+  }
+
+  private[this] def parseOpt(in: JsonInput, useBigDecimalForDouble: Boolean = false): Option[JValue] = allCatch opt {
+    parse(in, useBigDecimalForDouble)
+  }
+
+  private[this] def render(value: JValue): JValue = value
+
+  private[this] def pretty(d: JValue): String = {
+    val writer: ObjectWriter = mapper.writerWithDefaultPrettyPrinter()
+    writer.writeValueAsString(d)
+  }
+
+  def asJValue[T](obj: T)(implicit writer: Writer[T]): JValue = writer.write(obj)
+
+  def fromJValue[T](json: JValue)(implicit reader: Reader[T]): T = reader.read(json)
+
+  /**
+   * Returns JSON string value.
+   *
+   * @param value value
+   */
+  def compact(value: JValue): String = {
+    val json = mapper.writeValueAsString(value)
+    if (useJSONVulnerabilityProtection) prefixForJSONVulnerabilityProtection + json
+    else json
+  }
+
+  /**
+   * Converts a value to JSON value.
+   *
+   * @param v value
+   * @return JValue
+   */
+  def toJSON(v: Any): JValue = Extraction.decompose(v)
+
+  /**
+   * Converts a value to JSON string.
+   *
+   * @param v value
+   * @param underscoreKeys apply #underscoreKeys keys if true
+   * @return json string
+   */
+  def toJSONString(v: Any, underscoreKeys: Boolean = useUnderscoreKeysForJSON): String = {
+    if (underscoreKeys) compact(parse(compact(toJSON(v))).underscoreKeys)
+    else compact(toJSON(v))
+  }
+
+  /**
+   * Converts a value to JSON string without key conversions.
+   *
+   * @param v value
+   * @return json string
+   */
+  def toJSONStringAsIs(v: Any): String = toJSONString(v, false)
+
+  /**
+   * Converts a value to prettified JSON string.
+   *
+   * @param v value
+   * @param underscoreKeys apply #underscoreKeys keys if true
+   * @return json string
+   */
+  def toPrettyJSONString(v: Any, underscoreKeys: Boolean = useUnderscoreKeysForJSON): String = {
+    if (underscoreKeys) pretty(parse(compact(toJSON(v))).underscoreKeys)
+    else pretty(toJSON(v))
+  }
+
+  /**
+   * Converts a value to prettified JSON string without key conversions.
+   *
+   * @param v value
+   * @return json string
+   */
+  def toPrettyJSONStringAsIs(v: Any): String = toPrettyJSONString(v, false)
+
+  /**
+   * Extracts a value from JSON string.
+   * NOTE: When you convert to Map objects, be aware that underscoreKeys is false by default.
+   *
+   * @param json json string
+   * @param underscoreKeys apply #underscoreKeys keys if true
+   * @param asIs never apply key conversions if true
+   * @tparam A return type
+   * @return value
+   */
+  def fromJSONString[A](json: String, underscoreKeys: Boolean = false, asIs: Boolean = false)(implicit mf: Manifest[A]): Option[A] = {
+    fromJSONStringToJValue(json, underscoreKeys, asIs).map[A](_.extract[A])
+  }
+
+  /**
+   * Extracts a value from JSON string. The keys will be used as-is.
+   *
+   * {{{
+   *   case class Something(fooBar_baz: String)
+   *   val something = new Something("foo")
+   *   val json = toJSONString(something)
+   *   val something2 = fromJSONStringAsIs[Something](json)
+   *   something2.map(_.fooBar_baz) should equal(Some(something.fooBar_Baz))
+   * }}}
+   *
+   * @param json json string
+   * @param mf manifest
+   * @tparam A return type
+   * @return value
+   */
+  def fromJSONStringAsIs[A](json: String)(implicit mf: Manifest[A]): Option[A] = fromJSONString(json, false, true)
+
+  /**
+   * Extracts a JSON value from JSON string.
+   * NOTE: When you convert to Map objects, be aware that underscoreKeys is false by default.
+   *
+   * @param json json string
+   * @param underscoreKeys underscore keys
+   * @return value
+   */
+  def fromJSONStringToJValue(json: String, underscoreKeys: Boolean = false, asIs: Boolean = false): Option[JValue] = {
+    val pureJson = if (useJSONVulnerabilityProtection &&
+      json.startsWith(prefixForJSONVulnerabilityProtection)) {
+      json.replace(prefixForJSONVulnerabilityProtection, "")
+    } else {
+      json
+    }
+    parseOpt(StringInput(pureJson)).map { v =>
+      if (asIs) v
+      else if (underscoreKeys) v.underscoreKeys
+      else v.camelizeKeys
+    }
+  }
+
+}
+
+object JSONStringOps
+  extends JSONStringOps

--- a/micro-json4s/src/main/scala/skinny/micro/contrib/json4s/JSONParamsAutoBinderSupport.scala
+++ b/micro-json4s/src/main/scala/skinny/micro/contrib/json4s/JSONParamsAutoBinderSupport.scala
@@ -1,15 +1,15 @@
-package skinny.micro.contrib
+package skinny.micro.contrib.json4s
 
-import java.io.{ InputStreamReader, InputStream }
+import java.io.{ InputStream, InputStreamReader }
 
 import org.json4s.Xml._
 import org.json4s._
 import org.slf4j.LoggerFactory
-import skinny.micro.context.SkinnyContext
-import skinny.json.JSONStringOps
-import skinny.micro.{ SkinnyMicroBase, SkinnyMicroParams, Params, ApiFormats }
-import skinny.micro.routing.MatchedRoute
+import skinny.json4s.JSONStringOps
 import skinny.logging.LoggerProvider
+import skinny.micro.context.SkinnyContext
+import skinny.micro.routing.MatchedRoute
+import skinny.micro.{ ApiFormats, Params, SkinnyMicroBase, SkinnyMicroParams }
 
 /**
  * Merging JSON request body into Scalatra params.

--- a/micro-json4s/src/main/scala/skinny/micro/contrib/json4s/JSONSupport.scala
+++ b/micro-json4s/src/main/scala/skinny/micro/contrib/json4s/JSONSupport.scala
@@ -1,6 +1,6 @@
-package skinny.micro.contrib
+package skinny.micro.contrib.json4s
 
-import skinny.json.JSONStringOps
+import skinny.json4s._
 import skinny.micro.context.SkinnyContext
 import skinny.micro.{ Format, SkinnyMicroBase }
 
@@ -28,8 +28,8 @@ trait JSONSupport extends JSONStringOps { self: SkinnyMicroBase =>
       (contentType = Format.JSON.contentType + charset.map(c => s"; charset=${c}").getOrElse(""))(ctx)
     }
 
-    if (prettify) toPrettyJSONString(entity, underscoreKeys = underscoreKeys)
-    else toJSONString(value = entity, underscoreKeys = underscoreKeys)
+    if (prettify) toPrettyJSONString(entity)
+    else toJSONString(entity, underscoreKeys)
   }
 
 }

--- a/micro-json4s/src/test/resources/logback.xml
+++ b/micro-json4s/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="default" class="ch.qos.logback.core.FileAppender">
+        <file>logs/console.log</file>
+        <encoder>
+          <pattern>%date %level [%thread] %logger{64} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="warn"/>
+    <logger name="org.fusesource.scalate" level="warn"/>
+    <logger name="org.scalatra.scalate.ScalateSupport##anonfun#createTemplateEngine#2##anon#1.SourceMap" level="warn"/>
+    <logger name="org.scalatra.scalate.ScalateSupport##anonfun#createTemplateEngine#2##anon#2.SourceMap" level="warn"/>
+
+    <root level="debug">
+        <appender-ref ref="default"/>
+    </root>
+</configuration>

--- a/micro-json4s/src/test/scala/example/FutureSpec.scala
+++ b/micro-json4s/src/test/scala/example/FutureSpec.scala
@@ -1,0 +1,66 @@
+package example
+
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import skinny.micro.contrib.json4s.JSONSupport
+import skinny.micro.{ AsyncSkinnyMicroServlet, ServletConcurrencyException }
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class FutureSpec extends ScalatraFlatSpec {
+
+  addServlet(new AsyncSkinnyMicroServlet with JSONSupport {
+
+    get("/") { implicit ctx =>
+      responseAsJSON(params)
+    }
+
+    get("/future") { implicit ctx =>
+      Future {
+        responseAsJSON(params)
+      }
+    }
+
+    get("/no-future-error") { implicit ctx =>
+      responseAsJSON(awaitFutures(3.seconds) {
+        Future {
+          try {
+            responseAsJSON(params)
+          } catch {
+            case e: ServletConcurrencyException =>
+              Map("message" -> e.getMessage)
+          }
+        }
+      })
+    }
+  }, "/*")
+
+  it should "simply work" in {
+    get("/?foo=bar") {
+      status should equal(200)
+      body should equal("""{"foo":"bar"}""")
+    }
+  }
+  it should "fail with simple Future" in {
+    get("/no-future-error?foo=bar") {
+      status should equal(200)
+      var found = false
+      var count = 0
+      while (!found && count < 10) {
+        if (body.contains("Concurrency Issue Detected")) {
+          found = true
+        } else {
+          count += 1
+        }
+      }
+      found should be(false)
+    }
+  }
+  it should "work with futureWithContext" in {
+    get("/future?foo=bar") {
+      status should equal(200)
+      body should equal("""{"foo":"bar"}""")
+    }
+  }
+
+}

--- a/micro-json4s/src/test/scala/example/HelloServletSpec.scala
+++ b/micro-json4s/src/test/scala/example/HelloServletSpec.scala
@@ -1,0 +1,42 @@
+package example
+
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import skinny.micro._
+import skinny.micro.contrib.json4s.JSONSupport
+
+import scala.concurrent.Future
+
+object HelloServlet extends SingleApp with JSONSupport {
+
+  def message(implicit ctx: Context) = {
+    s"Hello, ${params(ctx).getOrElse("name", "Anonymous")}"
+  }
+
+  // returns JSON response
+  get("/hello/json") {
+    responseAsJSON(Map("message" -> message))
+  }
+  get("/hello/json/async") {
+    implicit val ctx = context
+    Future {
+      responseAsJSON(Map("message" -> s"Hello, ${params(ctx).getOrElse("name", "Anonymous")}"))(ctx)
+    }
+  }
+}
+
+class HelloServletSpec extends ScalatraFlatSpec {
+  addServlet(HelloServlet, "/*")
+
+  it should "return JSON response" in {
+    get("/hello/json") {
+      status should equal(200)
+      header("Content-Type") should equal("application/json; charset=utf-8")
+      body should equal("""{"message":"Hello, Anonymous"}""")
+    }
+    get("/hello/json/async?name=Martin") {
+      status should equal(200)
+      header("Content-Type") should equal("application/json; charset=utf-8")
+      body should equal("""{"message":"Hello, Martin"}""")
+    }
+  }
+}

--- a/micro-json4s/src/test/scala/example/HelloSpec.scala
+++ b/micro-json4s/src/test/scala/example/HelloSpec.scala
@@ -1,0 +1,97 @@
+package example
+
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import skinny.micro._
+import skinny.micro.async.AsyncResult
+import skinny.micro.contrib.json4s.JSONSupport
+
+import scala.concurrent.Future
+
+object Hello extends WebApp with JSONSupport {
+
+  def message(implicit ctx: Context) = {
+    s"Hello, ${params(ctx).getOrElse("name", "Anonymous")}"
+  }
+
+  // synchronous action
+  get("/hello")(message)
+  post("/hello")(message)
+
+  // asynchronous action
+  get("/hello/async") {
+    implicit val ctx = context
+    Future { message(ctx) }
+  }
+
+  // returns JSON response
+  get("/hello/json") {
+    responseAsJSON(Map("message" -> message))
+  }
+  get("/hello/json/async") {
+    AsyncResult {
+      responseAsJSON(Map("message" -> s"Hello, ${params.getOrElse("name", "Anonymous")}"))
+    }
+  }
+
+  get("/dynamic") {
+    Future {
+      request
+    }
+  }
+}
+
+class HelloSpec extends ScalatraFlatSpec {
+  addFilter(Hello, "/*")
+
+  it should "work fine with GET Requests" in {
+    get("/hello") {
+      status should equal(200)
+      body should equal("Hello, Anonymous")
+    }
+    get("/hello?name=Martin") {
+      status should equal(200)
+      body should equal("Hello, Martin")
+    }
+  }
+
+  it should "work fine with POST Requests" in {
+    post("/hello", Map()) {
+      status should equal(200)
+      body should equal("Hello, Anonymous")
+    }
+    post("/hello", Map("name" -> "Martin")) {
+      status should equal(200)
+      body should equal("Hello, Martin")
+    }
+  }
+
+  it should "work fine with AsyncResult" in {
+    get("/hello/async") {
+      status should equal(200)
+      body should equal("Hello, Anonymous")
+    }
+    get("/hello/async?name=Martin") {
+      status should equal(200)
+      body should equal("Hello, Martin")
+    }
+  }
+
+  it should "return JSON response" in {
+    get("/hello/json") {
+      status should equal(200)
+      header("Content-Type") should equal("application/json; charset=utf-8")
+      body should equal("""{"message":"Hello, Anonymous"}""")
+    }
+    get("/hello/json/async?name=Martin") {
+      status should equal(200)
+      header("Content-Type") should equal("application/json; charset=utf-8")
+      body should equal("""{"message":"Hello, Martin"}""")
+    }
+  }
+
+  it should "detect dynamic value access when the first access" in {
+    get("/dynamic") {
+      status should equal(500)
+    }
+  }
+}

--- a/micro-json4s/src/test/scala/example/JSONOperationSpec.scala
+++ b/micro-json4s/src/test/scala/example/JSONOperationSpec.scala
@@ -1,0 +1,32 @@
+package example
+
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import skinny.micro.SkinnyMicroServlet
+import skinny.micro.contrib.json4s.JSONSupport
+
+class JSONOperationSpec extends ScalatraFlatSpec {
+
+  object App extends SkinnyMicroServlet with JSONSupport {
+    def name = params.getAs[String]("name").getOrElse("Anonymous")
+
+    get("/hello") {
+      responseAsJSON(Map("message" -> s"Hello, $name"))
+    }
+  }
+  addServlet(App, "/*")
+
+  it should "work" in {
+    get("/hello") {
+      status should equal(200)
+      header("Content-Type") should equal("application/json; charset=utf-8")
+      body should equal("""{"message":"Hello, Anonymous"}""")
+    }
+
+    get("/hello?name=Martin") {
+      status should equal(200)
+      header("Content-Type") should equal("application/json; charset=utf-8")
+      body should equal("""{"message":"Hello, Martin"}""")
+    }
+  }
+
+}

--- a/micro-json4s/src/test/scala/example/JSONParamsAutoBinderSupportSpec.scala
+++ b/micro-json4s/src/test/scala/example/JSONParamsAutoBinderSupportSpec.scala
@@ -1,9 +1,9 @@
 package example
 
 import org.scalatra.test.scalatest.ScalatraFlatSpec
-import skinny.json.JSONStringOps
+import skinny.json4s.JSONStringOps
 import skinny.micro.WebApp
-import skinny.micro.contrib.JSONParamsAutoBinderSupport
+import skinny.micro.contrib.json4s.JSONParamsAutoBinderSupport
 
 class JSONParamsAutoBinderSupportSpec extends ScalatraFlatSpec {
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ import scala.language.postfixOps
 
 object SkinnyMicroBuild extends Build {
 
-  lazy val currentVersion = "0.9.6"
+  lazy val currentVersion = "0.9.7-SNAPSHOT"
 
   lazy val json4SVersion = "3.3.0.RC4"
   lazy val scalatraTestVersion = "2.3.1"
@@ -97,6 +97,19 @@ object SkinnyMicroBuild extends Build {
   lazy val microJson = Project(id = "microJson", base = file("micro-json"),
     settings = baseSettings ++ Seq(
       name := "skinny-micro-json",
+      libraryDependencies ++= servletApiDependencies ++ jacksonDependencies ++ Seq(
+        "joda-time"         %  "joda-time"          % "2.8.2"             % Compile,
+        "org.joda"          %  "joda-convert"       % "1.7"               % Compile,
+        "org.scalatra"      %% "scalatra-specs2"    % scalatraTestVersion % Test,
+        "org.scalatra"      %% "scalatra-scalatest" % scalatraTestVersion % Test,
+        "com.typesafe.akka" %% "akka-actor"         % "2.3.12"            % Test
+      ) ++ testDependencies
+    )
+  ).dependsOn(micro)
+
+  lazy val microJson4s = Project(id = "microJson4s", base = file("micro-json4s"),
+    settings = baseSettings ++ Seq(
+      name := "skinny-micro-json4s",
       libraryDependencies ++= servletApiDependencies ++ json4sDependencies ++ Seq(
         "joda-time"         %  "joda-time"          % "2.8.2"             % Compile,
         "org.joda"          %  "joda-convert"       % "1.7"               % Compile,
@@ -170,6 +183,9 @@ object SkinnyMicroBuild extends Build {
   )
   lazy val slf4jApiDependencies   = Seq(
     "org.slf4j"     % "slf4j-api"         % slf4jApiVersion % Compile
+  )
+  lazy val jacksonDependencies   = Seq(
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.1" % Compile excludeAll(fullExclusionRules: _*)
   )
   lazy val json4sDependencies = Seq(
     "org.json4s"    %% "json4s-jackson"     % json4SVersion    % Compile  excludeAll(fullExclusionRules: _*),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object SkinnyMicroBuild extends Build {
 
   lazy val currentVersion = "0.9.6"
 
-  lazy val json4SVersion = "3.3.0.RC3"
+  lazy val json4SVersion = "3.3.0.RC4"
   lazy val scalatraTestVersion = "2.3.1"
   lazy val mockitoVersion = "1.10.19"
   // Jetty 9.3 dropped Java 7
@@ -85,7 +85,7 @@ object SkinnyMicroBuild extends Build {
           "com.googlecode.juniversalchardet" %  "juniversalchardet" % "1.0.3"     % Compile,
           "org.scalatra"      %% "scalatra-specs2"          % scalatraTestVersion % Test,
           "org.scalatra"      %% "scalatra-scalatest"       % scalatraTestVersion % Test,
-          "com.typesafe.akka" %% "akka-actor"               % "2.3.12"            % Test
+          "com.typesafe.akka" %% "akka-actor"               % "2.3.13"            % Test
         ) ++ (sv match {
           case v if v.startsWith("2.11.") => Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4" % Compile)
           case _ => Nil
@@ -149,7 +149,7 @@ object SkinnyMicroBuild extends Build {
     settings = baseSettings ++ Seq(
       libraryDependencies ++= Seq(
         "com.typesafe.slick" %% "slick"     % "3.0.2",
-        "org.slf4j"          %  "slf4j-nop" % "1.6.4",
+        "org.slf4j"          %  "slf4j-nop" % "1.7.12",
         "com.h2database"     %  "h2"        % "1.4.188"
       ) ++ testDependencies
     )

--- a/publish.sh
+++ b/publish.sh
@@ -5,6 +5,7 @@ sbt ++2.11.7 \
   microCommon/publishSigned \
   micro/publishSigned \
   microJson/publishSigned \
+  microJson4s/publishSigned \
   microScalate/publishSigned \
   microServer/publishSigned \
   microTest/publishSigned \
@@ -13,6 +14,7 @@ sbt ++2.11.7 \
   microCommon/publishSigned \
   micro/publishSigned \
   microJson/publishSigned \
+  microJson4s/publishSigned \
   microScalate/publishSigned \
   microServer/publishSigned \
   microTest/publishSigned

--- a/publish_local.sh
+++ b/publish_local.sh
@@ -5,6 +5,7 @@ sbt ++2.11.7 \
   microCommon/publishLocal \
   micro/publishLocal \
   microJson/publishLocal \
+  microJson4s/publishLocal \
   microScalate/publishLocal \
   microServer/publishLocal \
   microTest/publishLocal \
@@ -13,6 +14,7 @@ sbt ++2.11.7 \
   microCommon/publishLocal \
   micro/publishLocal \
   microJson/publishLocal \
+  microJson4s/publishLocal \
   microScalate/publishLocal \
   microServer/publishLocal \
   microTest/publishLocal

--- a/samples/src/main/scala/sample/async_native/ReactiveSlickApp.scala
+++ b/samples/src/main/scala/sample/async_native/ReactiveSlickApp.scala
@@ -17,6 +17,11 @@ class ReactiveSlickApp extends AsyncWebApp with JSONSupport {
   before() { implicit ctx =>
     contentType = "application/json"
   }
+  error {
+    case e =>
+      e.printStackTrace
+      throw e
+  }
 
   get("/slick-demo/suppliers") { implicit ctx =>
     db.run(suppliers.result).map { ss =>

--- a/samples/src/main/scala/sample/standalone_app/OnlineJSONFormatter.scala
+++ b/samples/src/main/scala/sample/standalone_app/OnlineJSONFormatter.scala
@@ -16,9 +16,14 @@ object OnlineJSONFormatter extends App {
     new AsyncWebApp with JSONSupport {
       post("/prettify") { implicit ctx =>
         contentType = "application/json"
-        fromJSONStringToJValue(request.body, asIs = true) match {
-          case Some(json) => Ok(toPrettyJSONStringAsIs(json))
-          case _ => BadRequest(toJSONString(Map("error" -> "JSON parse error")))
+        try {
+          fromJSONString[Map[String, Any]](request.body) match {
+            case Some(value) => Ok(toPrettyJSONString(value))
+            case _ => BadRequest(toJSONString(Map("error" -> "Failed to parse JSON string")))
+          }
+        } catch {
+          case e: Exception =>
+            BadRequest(toJSONString(Map("error" -> e.getMessage)))
         }
       }
     }

--- a/samples/src/test/scala/sample/async_native/ReactiveSlickAppSpec.scala
+++ b/samples/src/test/scala/sample/async_native/ReactiveSlickAppSpec.scala
@@ -10,6 +10,7 @@ class ReactiveSlickAppSpec extends SkinnyFunSpec with JSONStringOps {
 
     it("shows coffees") {
       get("/slick-demo/coffees") {
+        if (status != 200) println(body)
         status should equal(200)
         header("Content-Type") should equal("application/json; charset=UTF-8")
       }
@@ -17,6 +18,7 @@ class ReactiveSlickAppSpec extends SkinnyFunSpec with JSONStringOps {
 
     it("shows suppliers") {
       get("/slick-demo/suppliers") {
+        if (status != 200) println(body)
         status should equal(200)
         header("Content-Type") should equal("application/json; charset=UTF-8")
       }

--- a/samples/src/test/scala/sample/async_native/ReactiveSlickAppSpec.scala
+++ b/samples/src/test/scala/sample/async_native/ReactiveSlickAppSpec.scala
@@ -1,7 +1,7 @@
 package sample.async_native
 
-import skinny.test.SkinnyFunSpec
 import skinny.json.JSONStringOps
+import skinny.test.SkinnyFunSpec
 
 class ReactiveSlickAppSpec extends SkinnyFunSpec with JSONStringOps {
   addFilter(classOf[ReactiveSlickApp], "/*")

--- a/samples/src/test/scala/sample/scalatra_compatible/EchoAppSpec.scala
+++ b/samples/src/test/scala/sample/scalatra_compatible/EchoAppSpec.scala
@@ -1,7 +1,7 @@
 package sample.scalatra_compatible
 
-import skinny.test.SkinnyFunSpec
 import skinny.json.JSONStringOps
+import skinny.test.SkinnyFunSpec
 
 class EchoAppSpec extends SkinnyFunSpec with JSONStringOps {
   addFilter(classOf[EchoApp], "/*")


### PR DESCRIPTION
This pull request replaces skinny-micro-json with onew one which is based on only jackson-scala-module. Existing json4s-based module is renamed as skinny-micro-json4s.

This is a breaking change for existing applications. But we should go with this to keep stability in skinny 2.x releases.