### PR TITLE
Avoid deserializing absent fields with null

### DIFF
--- a/micro-json/src/test/scala/example/JSONStringOpsSpec.scala
+++ b/micro-json/src/test/scala/example/JSONStringOpsSpec.scala
@@ -1,0 +1,32 @@
+package example
+
+import org.scalatest._
+import skinny.json.JSONStringOps
+
+case class SomeGroup(name: String, groupMembers: Seq[Member])
+case class Member(id: Long, name: Option[String])
+
+class JSONStringOpsSpec extends FunSpec with Matchers with JSONStringOps {
+
+  val members = Seq(
+    Member(1, Some("Alice")),
+    Member(2, Some("Bob")),
+    Member(3, None),
+    Member(4, Some("Denis"))
+  )
+
+  describe("JSONStringOps") {
+    it("should serialize normal data") {
+      val group = SomeGroup("Igo", members)
+      val expected = """{"name":"Igo","group_members":[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"},{"id":3,"name":null},{"id":4,"name":"Denis"}]}"""
+      toJSONString(group) should equal(expected)
+    }
+
+    it("should work with non-existing fields") {
+      val json = """{"name":"Igo"}"""
+      val expected = SomeGroup("Igo", Seq.empty)
+      fromJSONString[SomeGroup](json).isFailure should equal(true)
+    }
+  }
+
+}

--- a/micro-xml/src/test/scala/example/XMLStringOpsSpec.scala
+++ b/micro-xml/src/test/scala/example/XMLStringOpsSpec.scala
@@ -1,0 +1,32 @@
+package example
+
+import org.scalatest._
+import skinny.xml.XMLStringOps
+
+case class SomeGroup(name: String, groupMembers: Seq[Member])
+case class Member(id: Long, name: Option[String])
+
+class XMLStringOpsSpec extends FunSpec with Matchers with XMLStringOps {
+
+  val members = Seq(
+    Member(1, Some("Alice")),
+    Member(2, Some("Bob")),
+    Member(3, None),
+    Member(4, Some("Denis"))
+  )
+
+  describe("JSONStringOps") {
+    it("should serialize normal data") {
+      val group = SomeGroup("Igo", members)
+      val expected = """<?xml version="1.0" encoding="UTF-8"?><response><name>Igo</name><groupMembers><id>1</id><name>Alice</name></groupMembers><groupMembers><id>2</id><name>Bob</name></groupMembers><groupMembers><id>3</id><name/></groupMembers><groupMembers><id>4</id><name>Denis</name></groupMembers></response>"""
+      toXMLString(group) should equal(expected)
+    }
+
+    it("should work with non-existing fields") {
+      val xml = """<?xml version="1.0" encoding="UTF-8"?><response><name>Igo</name></response>"""
+      val expected = SomeGroup("Igo", Seq.empty)
+      fromXMLString[SomeGroup](xml).isFailure should equal(true)
+    }
+  }
+
+}


### PR DESCRIPTION
Unfortunately, jackson-module-scala maps absent fields as null. This pull request make skinny-micro's libs not to do so for now.

https://github.com/FasterXML/jackson-module-scala/issues/87
