### PR TITLE
Add new cookie creation APIs

### DIFF
--- a/micro/src/main/scala/skinny/micro/cookie/Cookie.scala
+++ b/micro/src/main/scala/skinny/micro/cookie/Cookie.scala
@@ -3,13 +3,38 @@ package skinny.micro.cookie
 import java.util.{ Date, Locale }
 import skinny.micro.implicits.RicherStringImplicits
 
-case class Cookie(name: String, value: String)(
-    implicit cookieOptions: CookieOptions = CookieOptions()) {
+case class Cookie(
+    name: String,
+    value: String)(implicit cookieOptions: CookieOptions = CookieOptions.default) {
 
   import Cookie._
   import RicherStringImplicits._
 
   val options: CookieOptions = cookieOptions
+
+  def withOptions(newOptions: CookieOptions): Cookie = new Cookie(name, value)(newOptions)
+
+  def withOptions(
+    domain: String = CookieOptions.default.domain,
+    path: String = CookieOptions.default.path,
+    maxAge: Int = CookieOptions.default.maxAge,
+    secure: Boolean = CookieOptions.default.secure,
+    comment: String = CookieOptions.default.comment,
+    httpOnly: Boolean = CookieOptions.default.httpOnly,
+    version: Int = CookieOptions.default.version,
+    encoding: String = CookieOptions.default.encoding): Cookie = {
+    val newOptions = CookieOptions(
+      domain = domain,
+      path = path,
+      maxAge = maxAge,
+      secure = secure,
+      comment = comment,
+      httpOnly = httpOnly,
+      version = version,
+      encoding = encoding
+    )
+    new Cookie(name, value)(newOptions)
+  }
 
   def toCookieString: String = {
     val sb = new StringBuilder
@@ -73,6 +98,8 @@ object Cookie {
   val SweetCookiesKey = "skinny.micro.SweetCookies"
 
   val CookieOptionsKey = "skinny.micro.CookieOptions"
+
+  def apply(keyValue: (String, String)): Cookie = new Cookie(keyValue._1, keyValue._2)
 
   private object DateUtil {
 

--- a/micro/src/main/scala/skinny/micro/cookie/CookieOptions.scala
+++ b/micro/src/main/scala/skinny/micro/cookie/CookieOptions.scala
@@ -12,3 +12,9 @@ case class CookieOptions(
   httpOnly: Boolean = false,
   version: Int = 0,
   encoding: String = "UTF-8")
+
+object CookieOptions {
+
+  val default = CookieOptions()
+
+}

--- a/micro/src/main/scala/skinny/micro/cookie/SweetCookies.scala
+++ b/micro/src/main/scala/skinny/micro/cookie/SweetCookies.scala
@@ -23,23 +23,23 @@ class SweetCookies(
   }
 
   def update(name: String, value: String)(
-    implicit cookieOptions: CookieOptions = CookieOptions()): Cookie = {
+    implicit cookieOptions: CookieOptions = CookieOptions.default): Cookie = {
     cookies += name -> value
     addCookie(name, value, cookieOptions)
   }
 
   def set(name: String, value: String)(
-    implicit cookieOptions: CookieOptions = CookieOptions()): Cookie = {
+    implicit cookieOptions: CookieOptions = CookieOptions.default): Cookie = {
     this.update(name, value)(cookieOptions)
   }
 
-  def delete(name: String)(implicit cookieOptions: CookieOptions = CookieOptions()): Unit = {
+  def delete(name: String)(implicit cookieOptions: CookieOptions = CookieOptions.default): Unit = {
     cookies -= name
     addCookie(name, "", cookieOptions.copy(maxAge = 0))
   }
 
   def +=(keyValuePair: (String, String))(
-    implicit cookieOptions: CookieOptions = CookieOptions()): Unit = {
+    implicit cookieOptions: CookieOptions = CookieOptions.default): Unit = {
     this.update(keyValuePair._1, keyValuePair._2)(cookieOptions)
   }
 
@@ -53,7 +53,7 @@ class SweetCookies(
     }
   }
 
-  def -=(key: String)(implicit cookieOptions: CookieOptions = CookieOptions()): Unit = {
+  def -=(key: String)(implicit cookieOptions: CookieOptions = CookieOptions.default): Unit = {
     delete(key)(cookieOptions)
   }
 

--- a/micro/src/test/scala/org/scalatra/CookieTest.scala
+++ b/micro/src/test/scala/org/scalatra/CookieTest.scala
@@ -14,13 +14,26 @@ class CookieTest extends WordSpec with Matchers with BeforeAndAfterAll {
       cookie.toCookieString should equal("theName=theValue")
     }
 
+    "render a simple name value pair (2)" in {
+      val cookie = Cookie("theName" -> "theValue")
+      cookie.toCookieString should equal("theName=theValue")
+    }
+
     "have a dot in front of the domain when set" in {
       val cookie = Cookie("cookiename", "value1")(CookieOptions(domain = "nowhere.com"))
+      cookie.toCookieString should equal("cookiename=value1; Domain=.nowhere.com")
+    }
+    "have a dot in front of the domain when set (2)" in {
+      val cookie = Cookie("cookiename", "value1").withOptions(domain = "nowhere.com")
       cookie.toCookieString should equal("cookiename=value1; Domain=.nowhere.com")
     }
 
     "prefix a path with / if a path is set" in {
       val cookie = Cookie("cookiename", "value1")(CookieOptions(path = "path/to/resource"))
+      cookie.toCookieString should equal("cookiename=value1; Path=/path/to/resource")
+    }
+    "prefix a path with / if a path is set (2)" in {
+      val cookie = Cookie("cookiename", "value1").withOptions(path = "path/to/resource")
       cookie.toCookieString should equal("cookiename=value1; Path=/path/to/resource")
     }
 
@@ -29,9 +42,18 @@ class CookieTest extends WordSpec with Matchers with BeforeAndAfterAll {
       val dateString = Cookie.formatExpires(new Date(Cookie.currentTimeMillis + 86700000))
       cookie.toCookieString should equal("cookiename=value1; Expires=" + dateString)
     }
+    "have a maxAge when the value is >= 0 (2)" in {
+      val cookie = Cookie("cookiename", "value1").withOptions(maxAge = 86700)
+      val dateString = Cookie.formatExpires(new Date(Cookie.currentTimeMillis + 86700000))
+      cookie.toCookieString should equal("cookiename=value1; Expires=" + dateString)
+    }
 
     "set the comment when a comment is given" in {
       val cookie = Cookie("cookiename", "value1")(CookieOptions(comment = "This is the comment"))
+      cookie.toCookieString should equal("cookiename=value1; Comment=This is the comment")
+    }
+    "set the comment when a comment is given (2)" in {
+      val cookie = Cookie("cookiename", "value1").withOptions(comment = "This is the comment")
       cookie.toCookieString should equal("cookiename=value1; Comment=This is the comment")
     }
 
@@ -39,9 +61,17 @@ class CookieTest extends WordSpec with Matchers with BeforeAndAfterAll {
       val cookie = Cookie("cookiename", "value1")(CookieOptions(secure = true))
       cookie.toCookieString should equal("cookiename=value1; Secure")
     }
+    "flag the cookie as secure if needed (2)" in {
+      val cookie = Cookie("cookiename", "value1").withOptions(secure = true)
+      cookie.toCookieString should equal("cookiename=value1; Secure")
+    }
 
     "flag the cookie as http only if needed" in {
       val cookie = Cookie("cookiename", "value1")(CookieOptions(httpOnly = true))
+      cookie.toCookieString should equal("cookiename=value1; HttpOnly")
+    }
+    "flag the cookie as http only if needed (2)" in {
+      val cookie = Cookie("cookiename", "value1").withOptions(httpOnly = true)
       cookie.toCookieString should equal("cookiename=value1; HttpOnly")
     }
 
@@ -54,6 +84,21 @@ class CookieTest extends WordSpec with Matchers with BeforeAndAfterAll {
         secure = true,
         httpOnly = true
       ))
+      val d = new Date(Cookie.currentTimeMillis + 15500 * 1000)
+      cookie.toCookieString should
+        equal("cookiename=value3; Domain=.nowhere.com; Path=/path/to/page; Comment=the cookie thingy comment; " +
+          "Expires=" + Cookie.formatExpires(d) + "; Secure; HttpOnly")
+    }
+
+    "render a cookie with all options set (2)" in {
+      val cookie = Cookie("cookiename", "value3").withOptions(
+        domain = "nowhere.com",
+        path = "path/to/page",
+        comment = "the cookie thingy comment",
+        maxAge = 15500,
+        secure = true,
+        httpOnly = true
+      )
       val d = new Date(Cookie.currentTimeMillis + 15500 * 1000)
       cookie.toCookieString should
         equal("cookiename=value3; Domain=.nowhere.com; Path=/path/to/page; Comment=the cookie thingy comment; " +


### PR DESCRIPTION
Existing Cookie creation:

```scala
val cookie = Cookie("foo", "bar")
val cookie = Cookie("foo", "bar")(CookieOptions(domain = "example.com", path = "/app"))
```

This pull request enables doing as below too:

```scala
val cookie = Cookie("foo", "bar")
val cookie = Cookie("foo", "bar").withOptions(domain = "example.com", path = "/app")

val cookie = Cookie("foo" -> "bar")
val cookie = Cookie("foo" -> "bar").withOptions(domain = "example.com", path = "/app")
```

