### PR TITLE
Add MostlyStableHttpSession implementation (disabled by default)

### DIFF
--- a/micro/src/main/scala/skinny/micro/UnstableAccessException.scala
+++ b/micro/src/main/scala/skinny/micro/UnstableAccessException.scala
@@ -11,6 +11,10 @@ class UnstableAccessException(attribute: String)
 object UnstableAccessException {
 
   def message(attribute: String): String = {
+    val workaround = {
+      if (attribute == "getSession") "Or, if you accept the risk, set the web controller's #useMostlyStableHttpSession as false (default: true)."
+      else "Or, if you accept the risk, set the web controller's #unstableAccessValidationEnabled as false (default: true)."
+    }
     s"""
       |
       |------------------------------------------------------
@@ -23,7 +27,7 @@ object UnstableAccessException {
       |
       |  Fix your code to copy needed values from $attribute as read-only ones before entering Future blocks.
       |
-      |  Or, if you accept the risk, set the web controller's #unstableAccessValidationEnabled as false (default: true).
+      |  $workaround
       |
       |------------------------------------------------------
       |""".stripMargin

--- a/micro/src/main/scala/skinny/micro/UnstableAccessValidation.scala
+++ b/micro/src/main/scala/skinny/micro/UnstableAccessValidation.scala
@@ -5,4 +5,5 @@ package skinny.micro
  */
 case class UnstableAccessValidation(
   enabled: Boolean,
+  useMostlyStableHttpSession: Boolean,
   createdThreadId: Long = Thread.currentThread.getId)

--- a/micro/src/main/scala/skinny/micro/base/SkinnyContextInitializer.scala
+++ b/micro/src/main/scala/skinny/micro/base/SkinnyContextInitializer.scala
@@ -57,7 +57,10 @@ trait SkinnyContextInitializer {
           ctx,
           req.value,
           resp.value,
-          UnstableAccessValidation(unstableAccessValidationEnabled)
+          UnstableAccessValidation(
+            unstableAccessValidationEnabled,
+            useMostlyStableHttpSession
+          )
         )
       case _ =>
         // If the dynamic variables are None, this code is running on another thread

--- a/micro/src/main/scala/skinny/micro/base/UnstableAccessValidationConfig.scala
+++ b/micro/src/main/scala/skinny/micro/base/UnstableAccessValidationConfig.scala
@@ -10,4 +10,9 @@ trait UnstableAccessValidationConfig {
    */
   protected def unstableAccessValidationEnabled: Boolean = true
 
+  /**
+   * Enables mostly stable Servlet HttpSession implementation instead.
+   */
+  protected def useMostlyStableHttpSession: Boolean = false
+
 }

--- a/micro/src/main/scala/skinny/micro/base/UrlGenerator.scala
+++ b/micro/src/main/scala/skinny/micro/base/UrlGenerator.scala
@@ -19,10 +19,6 @@ trait UrlGenerator extends RicherStringImplicits { self: SkinnyMicroBase =>
     }
   }
 
-  private[this] def appendSessionIdToUri(uri: String)(implicit ctx: SkinnyContext): String = {
-    ctx.response.encodeURL(uri)
-  }
-
   def relativeUrl(
     path: String,
     params: Iterable[(String, Any)] = Iterable.empty,
@@ -49,8 +45,7 @@ trait UrlGenerator extends RicherStringImplicits { self: SkinnyMicroBase =>
     params: Iterable[(String, Any)] = Iterable.empty,
     includeContextPath: Boolean = true,
     includeServletPath: Boolean = true,
-    absolutize: Boolean = true,
-    withSessionId: Boolean = true)(implicit ctx: SkinnyContext): String = {
+    absolutize: Boolean = true)(implicit ctx: SkinnyContext): String = {
     try {
       val newPath = path match {
         case x if x.startsWith("/") && includeContextPath && includeServletPath =>
@@ -70,7 +65,7 @@ trait UrlGenerator extends RicherStringImplicits { self: SkinnyMicroBase =>
         case (key, value) => key.urlEncode + "=" + value.toString.urlEncode
       }
       val queryString = if (pairs.isEmpty) "" else pairs.mkString("?", "&", "")
-      if (withSessionId) appendSessionIdToUri(newPath + queryString)(ctx) else newPath + queryString
+      newPath + queryString
     } catch {
       case e: NullPointerException =>
         // FIXME: 2.0.0 still has this issue.

--- a/micro/src/main/scala/skinny/micro/contrib/FlashMapSupport.scala
+++ b/micro/src/main/scala/skinny/micro/contrib/FlashMapSupport.scala
@@ -36,7 +36,8 @@ trait FlashMapSupport
 
   abstract override def handle(req: HttpServletRequest, res: HttpServletResponse): Unit = {
     withRequest(req) {
-      val context = SkinnyContext.build(servletContext, req, res, UnstableAccessValidation(unstableAccessValidationEnabled))
+      val context = SkinnyContext.build(servletContext, req, res,
+        UnstableAccessValidation(unstableAccessValidationEnabled, useMostlyStableHttpSession))
       val f = flash(context)
       val isOutermost = !req.contains(LockKey)
 

--- a/micro/src/main/scala/skinny/micro/request/MostlyStableHttpSession.scala
+++ b/micro/src/main/scala/skinny/micro/request/MostlyStableHttpSession.scala
@@ -1,0 +1,138 @@
+package skinny.micro.request
+
+import java.util.{ Collections, Date }
+import javax.servlet.ServletContext
+import javax.servlet.http.{ HttpServletRequest, HttpSessionContext, HttpSession }
+import skinny.logging.LoggerProvider
+
+import scala.collection.JavaConverters._
+
+import scala.collection.concurrent.TrieMap
+import scala.util.Try
+import scala.util.control.NonFatal
+
+/**
+ * Mostly stable Servlet HttpSession implementation.
+ *
+ * Since this implementation never throws exception even when Servlet containers have recycled request/session objects,
+ * it works mostly as we expected within Future operations.
+ *
+ * This implementation doesn't completely guarantee attributes' consistency in the session
+ * because #setAttribute after objects recycle cannot save the value in memory managed by Servlet containers.
+ *
+ * If you expect read-only stable session in Future threads, this implementation works fine as you expected.
+ */
+case class MostlyStableHttpSession(request: HttpServletRequest) extends HttpSession with LoggerProvider {
+
+  private[this] val attributes: TrieMap[String, Any] = new TrieMap[String, Any]()
+
+  // create session if absent
+  private[this] def underlying: HttpSession = request.getSession(true)
+
+  private[this] val _isNew: Boolean = underlying != null && underlying.isNew
+
+  private[this] def isUnderlyingAvailable: Boolean = {
+    underlying != null && Try(underlying.getId).isSuccess
+  }
+
+  if (underlying != null && !_isNew) {
+    underlying.getAttributeNames.asScala.foreach { name =>
+      attributes.put(name, underlying.getAttribute(name))
+    }
+  }
+
+  private[this] val createdTime = new Date
+
+  private[this] val _getMaxInactiveInterval: Int = {
+    if (underlying != null) underlying.getMaxInactiveInterval
+    else 0
+  }
+
+  private[this] var id: String = {
+    if (underlying != null && !underlying.isNew) underlying.getId
+    else Thread.currentThread.getId + "-" + createdTime.getTime
+  }
+
+  private[this] def refreshId(): Unit = {
+    id = Thread.currentThread.getId + "-" + createdTime.getTime
+  }
+
+  private[this] def unsupportedOperationError(msg: String) = throw new UnsupportedOperationException(msg)
+
+  override def getValue(name: String): AnyRef = attributes.get(name).map(_.asInstanceOf[AnyRef]).orNull[AnyRef]
+
+  override def isNew: Boolean = _isNew
+
+  override def getValueNames: Array[String] = attributes.keys.toArray
+
+  override def getLastAccessedTime: Long = createdTime.getTime
+
+  override def putValue(name: String, value: scala.Any): Unit = {
+    attributes.put(name, value)
+  }
+
+  override def getSessionContext: HttpSessionContext = unsupportedOperationError("#getSessionContext is unsupported")
+
+  override def getAttribute(name: String): AnyRef = getValue(name)
+
+  override def removeAttribute(name: String): Unit = {
+    removeAttribute(name)
+  }
+
+  override def getId: String = id
+
+  override def setMaxInactiveInterval(interval: Int): Unit = {
+    if (isUnderlyingAvailable) {
+      try underlying.setMaxInactiveInterval(interval)
+      catch {
+        case NonFatal(e) =>
+          logger.debug(s"Failed to execute underlying session's setMaxInactiveInterval method because ${e.getMessage}", e)
+      }
+    } else {
+      unsupportedOperationError("#setMaxInactiveInterval is unsupported")
+    }
+  }
+
+  override def getAttributeNames: java.util.Enumeration[String] = Collections.enumeration(attributes.keys.toList.asJava)
+
+  override def setAttribute(name: String, value: Any): Unit = {
+    attributes.put(name, value)
+    if (isUnderlyingAvailable) {
+      try underlying.setAttribute(name, value)
+      catch {
+        case NonFatal(e) =>
+          logger.debug(s"Failed to execute underlying session's setAttribute method because ${e.getMessage}", e)
+      }
+    }
+  }
+
+  override def invalidate(): Unit = {
+    refreshId()
+    attributes.clear()
+    if (isUnderlyingAvailable) {
+      try underlying.invalidate()
+      catch {
+        case NonFatal(e) =>
+          logger.debug(s"Failed to execute underlying session's invalidate method because ${e.getMessage}", e)
+      }
+    }
+  }
+
+  override def getCreationTime: Long = createdTime.getTime
+
+  override def removeValue(name: String): Unit = {
+    attributes.remove(name)
+    if (isUnderlyingAvailable) {
+      try underlying.removeAttribute(name)
+      catch {
+        case NonFatal(e) =>
+          logger.debug(s"Failed to execute underlying session's removeAttribute(${name}) method because ${e.getMessage}", e)
+      }
+    }
+  }
+
+  override def getServletContext: ServletContext = unsupportedOperationError("#getServletContext is unsupported")
+
+  override def getMaxInactiveInterval: Int = _getMaxInactiveInterval
+
+}

--- a/micro/src/main/scala/skinny/micro/routing/AsyncRoutingDsl.scala
+++ b/micro/src/main/scala/skinny/micro/routing/AsyncRoutingDsl.scala
@@ -74,7 +74,8 @@ trait AsyncRoutingDsl extends RoutingDslBase {
   protected def addRoute(method: HttpMethod, transformers: Seq[RouteTransformer], action: (Context) => Any): Route = {
     val route: Route = {
       val r = Route(transformers, () => action.apply(context), (req: HttpServletRequest) => routeBasePath(
-        SkinnyContext.buildWithoutResponse(req, servletContext, UnstableAccessValidation(unstableAccessValidationEnabled))))
+        SkinnyContext.buildWithoutResponse(req, servletContext,
+          UnstableAccessValidation(unstableAccessValidationEnabled, useMostlyStableHttpSession))))
       r.copy(metadata = r.metadata.updated(Handler.RouteMetadataHttpMethodCacheKey, method))
     }
     routes.prependRoute(method, route)

--- a/micro/src/main/scala/skinny/micro/routing/RoutingDsl.scala
+++ b/micro/src/main/scala/skinny/micro/routing/RoutingDsl.scala
@@ -74,7 +74,8 @@ trait RoutingDsl extends RoutingDslBase {
   protected def addRoute(method: HttpMethod, transformers: Seq[RouteTransformer], action: => Any): Route = {
     val route: Route = {
       val r = Route(transformers, () => action, (req: HttpServletRequest) => routeBasePath(
-        SkinnyContext.buildWithoutResponse(req, servletContext, UnstableAccessValidation(unstableAccessValidationEnabled))))
+        SkinnyContext.buildWithoutResponse(req, servletContext,
+          UnstableAccessValidation(unstableAccessValidationEnabled, useMostlyStableHttpSession))))
       r.copy(metadata = r.metadata.updated(Handler.RouteMetadataHttpMethodCacheKey, method))
     }
     routes.prependRoute(method, route)

--- a/micro/src/main/scala/skinny/micro/routing/TypedAsyncRoutingDsl.scala
+++ b/micro/src/main/scala/skinny/micro/routing/TypedAsyncRoutingDsl.scala
@@ -90,7 +90,8 @@ trait TypedAsyncRoutingDsl extends RoutingDslBase {
   protected def addRoute(method: HttpMethod, transformers: Seq[RouteTransformer], action: (Context) => AsyncResult): Route = {
     val route: Route = {
       val r = Route(transformers, () => action.apply(context), (req: HttpServletRequest) => routeBasePath(
-        SkinnyContext.buildWithoutResponse(req, servletContext, UnstableAccessValidation(unstableAccessValidationEnabled))))
+        SkinnyContext.buildWithoutResponse(req, servletContext,
+          UnstableAccessValidation(unstableAccessValidationEnabled, useMostlyStableHttpSession))))
       r.copy(metadata = r.metadata.updated(Handler.RouteMetadataHttpMethodCacheKey, method))
     }
     routes.prependRoute(method, route)

--- a/micro/src/main/scala/skinny/micro/routing/TypedRoutingDsl.scala
+++ b/micro/src/main/scala/skinny/micro/routing/TypedRoutingDsl.scala
@@ -83,7 +83,8 @@ trait TypedRoutingDsl extends RoutingDslBase {
   protected def addRoute(method: HttpMethod, transformers: Seq[RouteTransformer], action: => Any): Route = {
     val route: Route = {
       val r = Route(transformers, () => action, (req: HttpServletRequest) => routeBasePath(
-        SkinnyContext.buildWithoutResponse(req, servletContext, UnstableAccessValidation(unstableAccessValidationEnabled))))
+        SkinnyContext.buildWithoutResponse(req, servletContext,
+          UnstableAccessValidation(unstableAccessValidationEnabled, useMostlyStableHttpSession))))
       r.copy(metadata = r.metadata.updated(Handler.RouteMetadataHttpMethodCacheKey, method))
     }
     routes.prependRoute(method, route)

--- a/micro/src/test/scala/example/StableSessionSpec.scala
+++ b/micro/src/test/scala/example/StableSessionSpec.scala
@@ -1,0 +1,76 @@
+package example
+
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import skinny.micro.AsyncSkinnyMicroServlet
+
+import scala.concurrent.Future
+
+class StableSessionSpec extends ScalatraFlatSpec {
+
+  addServlet(new AsyncSkinnyMicroServlet {
+    override def useMostlyStableHttpSession = true
+
+    get("/foo") { implicit ctx =>
+      session.setAttribute("foo", "bar")
+      Future {
+        session.getAttribute("foo")
+      }
+    }
+
+    get("/bar") { implicit ctx =>
+      Future {
+        session.getAttribute("bar")
+      }
+    }
+    put("/bar") { implicit ctx =>
+      session.setAttribute("bar", params.get("value").orNull[String])
+      session.getAttribute("bar")
+    }
+    put("/bar/async") { implicit ctx =>
+      Future {
+        session.setAttribute("bar", params.get("value").orNull[String])
+        session.getAttribute("bar")
+      }
+    }
+
+  }, "/app/*")
+
+  it should "handle session attributes" in {
+    get("/app/foo") {
+      status should equal(200)
+      body should equal("bar")
+    }
+  }
+
+  it should "set/get session attributes" in {
+    session {
+      get("/app/bar") {
+        status should equal(200)
+        body should equal("")
+      }
+    }
+
+    session {
+      put("/app/bar", Map("value" -> "skinny-micro")) {
+        status should equal(200)
+        body should equal("skinny-micro")
+      }
+      get("/app/bar") {
+        status should equal(200)
+        body should equal("skinny-micro")
+      }
+    }
+
+    session {
+      put("/app/bar/async", Map("value" -> "12345")) {
+        status should equal(200)
+        body should equal("12345")
+      }
+      get("/app/bar") {
+        status should equal(200)
+        body should equal("12345")
+      }
+    }
+  }
+
+}

--- a/micro/src/test/scala/org/scalatra/UrlSupportTest.scala
+++ b/micro/src/test/scala/org/scalatra/UrlSupportTest.scala
@@ -8,7 +8,7 @@ class UrlSupportTest extends ScalatraFunSuite {
 
   addServlet(new SkinnyMicroServlet {
     get("/") {
-      if (params.contains("session")) session // trigger a jsessionid
+      if (params.contains("session")) session // Scalatra's test case: trigger a jsessionid
       this.url(params("url"), params - "url", absolutize = false)
     }
 
@@ -66,7 +66,8 @@ class UrlSupportTest extends ScalatraFunSuite {
 
   test("encodes URL through response") {
     session {
-      url("foo", Map("session" -> "session")) should include("jsessionid=")
+      // NOTE: skinny-micro never appends jsessionid
+      url("foo", Map("session" -> "session")) should not include ("jsessionid=")
     }
   }
 }


### PR DESCRIPTION
This pull request provides new Servlet HttpSession implementation. The `MostlyStableHttpSession` is, as its name describes, mostly stable even when using it within Future operations on the different threads.

Since this implementation never throws exception even when Servlet containers have recycled request/session objects, it works mostly as we expected within Future operations.

This implementation doesn't completely guarantee attributes' consistency in the session because #setAttribute after objects recycle cannot save the value in memory managed by Servlet containers.

If you expect read-only stable session in Future threads, this implementation works fine as you expected.
