### PR TITLE
Make existing routes APIs more useful

### DIFF
--- a/micro-server/src/main/scala/skinny/standalone/JettyServer.scala
+++ b/micro-server/src/main/scala/skinny/standalone/JettyServer.scala
@@ -58,7 +58,7 @@ trait JettyServer extends LoggerProvider {
   private[this] var listener: ServletContextListener = new SkinnyListener
 
   private[this] var _port: Int = {
-    // PORT: Heroku default env varaible
+    // PORT: Heroku default env variable
     Option(System.getenv("PORT")).map(_.toInt).getOrElse(8080)
   }
 

--- a/micro/src/main/scala/skinny/micro/base/RouteRegistryAccessor.scala
+++ b/micro/src/main/scala/skinny/micro/base/RouteRegistryAccessor.scala
@@ -10,6 +10,6 @@ trait RouteRegistryAccessor {
   /**
    * The routes registered in this kernel.
    */
-  protected val routes: RouteRegistry = new RouteRegistry
+  lazy val routes: RouteRegistry = RouteRegistry.getInstance(this)
 
 }

--- a/micro/src/test/scala/example/BeforeAfterFilterSpec.scala
+++ b/micro/src/test/scala/example/BeforeAfterFilterSpec.scala
@@ -10,6 +10,7 @@ class BeforeAfterFilterSpec extends ScalatraFlatSpec {
     before() {
       response.setHeader("x-first", "1")
     }
+    error { case e => e.printStackTrace() }
     get("/first") {
       "first one"
     }

--- a/micro/src/test/scala/example/RouteRegistrySpec.scala
+++ b/micro/src/test/scala/example/RouteRegistrySpec.scala
@@ -1,0 +1,80 @@
+package example
+
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import skinny.micro._
+import skinny.micro.routing.RouteRegistry
+
+class RouteRegistrySpec extends ScalatraFlatSpec {
+
+  RouteRegistry.init()
+
+  addFilter(new WebApp {
+    private def sayHelloTo(name: Option[String]): String = name match {
+      case Some(n) => s"Hello, $n!"
+      case _ => ""
+    }
+    private def sayHello(): String = sayHelloTo(params.get("name"))
+
+    get("/echo")(sayHello)
+    post("/echo")(sayHello)
+
+    get("/routes") {
+      routes.toString
+    }
+    get("/all-routes") {
+      RouteRegistry.toString
+    }
+  }, "/*")
+
+  addFilter(new WebApp {
+    private def sayHelloTo(name: Option[String]): String = name match {
+      case Some(n) => s"Hello, $n!"
+      case _ => ""
+    }
+    private def sayHello(): String = sayHelloTo(params.get("name"))
+
+    get("/hello/:name")(sayHello)
+    post("/good-bye/:name")(sayHello)
+  }, "/foo/*") // context path won't be appended to the routes
+
+  it should "echo via GET requests" in {
+    get("echo", "name" -> "Martin") {
+      status should equal(200)
+    }
+  }
+
+  it should "echo via POST requests" in {
+    post("/echo", "name" -> "Martin") {
+      status should equal(200)
+      body should equal("Hello, Martin!")
+    }
+
+  }
+
+  it should "show routes" in {
+    get("/routes") {
+      status should equal(200)
+      body should equal(
+        """GET	/all-routes
+          |GET	/echo
+          |GET	/routes
+          |POST	/echo
+          |""".stripMargin)
+    }
+  }
+
+  it should "show all routes" in {
+    get("/all-routes") {
+      status should equal(200)
+      body should equal(
+        """GET	/all-routes
+          |GET	/echo
+          |GET	/hello/:name
+          |GET	/routes
+          |POST	/echo
+          |POST	/good-bye/:name
+          |""".stripMargin)
+    }
+  }
+
+}

--- a/micro/src/test/scala/example/RouteRegistryWithoutBootstrapSpec.scala
+++ b/micro/src/test/scala/example/RouteRegistryWithoutBootstrapSpec.scala
@@ -1,0 +1,49 @@
+package example
+
+import org.scalatest._
+import skinny.micro._
+import skinny.micro.routing.RouteRegistry
+
+class RouteRegistryWithoutBootstrapSpec extends FlatSpec with Matchers {
+
+  RouteRegistry.init()
+
+  private def sayHello(): String = ???
+
+  val app1 = new WebApp {
+    get("/echo")(sayHello)
+    post("/echo")(sayHello)
+
+    get("/routes") {
+      routes.toString
+    }
+    get("/all-routes") {
+      RouteRegistry.toString
+    }
+  }
+  val app2 = new WebApp {
+    get("/hello/:name")(sayHello)
+    post("/good-bye/:name")(sayHello)
+  }
+
+  it should "show routes" in {
+    app1.routes.toString should equal(
+      """GET	/all-routes
+        |GET	/echo
+        |GET	/routes
+        |POST	/echo
+        |""".stripMargin)
+  }
+
+  it should "show all routes" in {
+    RouteRegistry.toString should equal(
+      """GET	/all-routes
+        |GET	/echo
+        |GET	/hello/:name
+        |GET	/routes
+        |POST	/echo
+        |POST	/good-bye/:name
+        |""".stripMargin)
+  }
+
+}

--- a/micro/src/test/scala/org/scalatra/RouteRegistryTest.scala
+++ b/micro/src/test/scala/org/scalatra/RouteRegistryTest.scala
@@ -16,12 +16,12 @@ object RouteRegistryTestServlet extends SkinnyMicroServlet {
 class RouteRegistryTest extends ScalatraFunSuite {
 
   test("route registry string representation contains the entry points") {
-    RouteRegistryTestServlet.renderRouteRegistry should equal(List(
-      "GET /foo",
-      "GET /nothing [Boolean Guard]",
-      "GET [Boolean Guard]",
-      "POST /foo/:bar",
-      "PUT ^/foo.../bar$"
-    ) mkString ", ")
+    RouteRegistryTestServlet.renderRouteRegistry should equal(Seq(
+      "GET\t/foo",
+      "GET\t/nothing [Boolean Guard]",
+      "GET\t[Boolean Guard]",
+      "POST\t/foo/:bar",
+      "PUT\t^/foo.../bar$"
+    ).mkString("\n") + "\n")
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,7 +18,7 @@ object SkinnyMicroBuild extends Build {
   lazy val jacksonVersion = "2.6.4"
   // Akka 2.4 dropped Scala 2.10 support
   lazy val akkaVersion = "2.3.14"
-  lazy val scalaTestVersion = "2.2.5"
+  lazy val scalaTestVersion = "2.2.6"
 
   lazy val baseSettings = Seq(
     organization := "org.skinny-framework",


### PR DESCRIPTION
Scalatra already had routes API. However, the API had some issues:

- Routes per controller (accessing all the routes in the whole webapp is not supported)
- RouteRegistry#toString method returns comma separated values
- No way to show routes without running Servlet containers

New API allows doing like this:

```scala
#!/usr/bin/env scalas
// or ./scalas Hello.scala
/***
scalaVersion := "2.11.7"
libraryDependencies += "org.skinny-framework" %% "skinny-micro-server" % "1.0.1-SNAPSHOT"
*/
import skinny.micro._
class HelloApp extends WebApp {
  private def sayHello = s"Hello, ${params.getOrElse("name", "Anonymous")}!\n"
  get("/say-hello")(sayHello)
  post("/say-hello-to/:name")(sayHello)
}
new HelloApp
println(skinny.micro.routing.RouteRegistry.toString)
```

Above example displays the following routes:

```
GET   /say-hello
POST  /say-hello-to/:name
```