### PR TITLE
Improvement for #19 - sort order of routes when displaying them via #toString

### DIFF
--- a/micro/src/main/scala/skinny/micro/Handler.scala
+++ b/micro/src/main/scala/skinny/micro/Handler.scala
@@ -69,7 +69,7 @@ trait Handler
   }
 
   private[this] def allRoutePaths: Seq[String] = {
-    routes.entryPoints
+    routes.entryPoints.map(_.toString)
       .flatMap(_.split("\\s+").tail.headOption.map(_.split("[:\\?]+").head))
       .distinct
       .flatMap { path =>

--- a/micro/src/test/scala/example/RouteRegistrySpec.scala
+++ b/micro/src/test/scala/example/RouteRegistrySpec.scala
@@ -57,8 +57,8 @@ class RouteRegistrySpec extends ScalatraFlatSpec {
       body should equal(
         """GET	/all-routes
           |GET	/echo
-          |GET	/routes
           |POST	/echo
+          |GET	/routes
           |""".stripMargin)
     }
   }
@@ -69,10 +69,10 @@ class RouteRegistrySpec extends ScalatraFlatSpec {
       body should equal(
         """GET	/all-routes
           |GET	/echo
-          |GET	/hello/:name
-          |GET	/routes
           |POST	/echo
           |POST	/good-bye/:name
+          |GET	/hello/:name
+          |GET	/routes
           |""".stripMargin)
     }
   }

--- a/micro/src/test/scala/example/RouteRegistryWithoutBootstrapSpec.scala
+++ b/micro/src/test/scala/example/RouteRegistryWithoutBootstrapSpec.scala
@@ -30,20 +30,20 @@ class RouteRegistryWithoutBootstrapSpec extends FlatSpec with Matchers {
     app1.routes.toString should equal(
       """GET	/all-routes
         |GET	/echo
-        |GET	/routes
         |POST	/echo
+        |GET	/routes
         |""".stripMargin)
   }
 
   it should "show all routes" in {
     RouteRegistry.toString should equal(
       """GET	/all-routes
-        |GET	/echo
-        |GET	/hello/:name
-        |GET	/routes
-        |POST	/echo
-        |POST	/good-bye/:name
-        |""".stripMargin)
+          |GET	/echo
+          |POST	/echo
+          |POST	/good-bye/:name
+          |GET	/hello/:name
+          |GET	/routes
+          |""".stripMargin)
   }
 
 }

--- a/micro/src/test/scala/org/scalatra/RouteRegistryTest.scala
+++ b/micro/src/test/scala/org/scalatra/RouteRegistryTest.scala
@@ -18,9 +18,9 @@ class RouteRegistryTest extends ScalatraFunSuite {
   test("route registry string representation contains the entry points") {
     RouteRegistryTestServlet.renderRouteRegistry should equal(Seq(
       "GET\t/foo",
+      "POST\t/foo/:bar",
       "GET\t/nothing [Boolean Guard]",
       "GET\t[Boolean Guard]",
-      "POST\t/foo/:bar",
       "PUT\t^/foo.../bar$"
     ).mkString("\n") + "\n")
   }


### PR DESCRIPTION
 - API Breaking Change: Change RouteRegistry#entryPoints's return type (String -> EntryPoint)
 - Improve sort order of routes when displaying them via #toString