### PR TITLE
Fix StableHttpServletRequest#getParameter not to throw NullPointerException

### DIFF
--- a/micro/src/main/scala/skinny/micro/request/StableHttpServletRequest.scala
+++ b/micro/src/main/scala/skinny/micro/request/StableHttpServletRequest.scala
@@ -259,7 +259,7 @@ class StableHttpServletRequest(
 
   override def getParameterNames: java.util.Enumeration[String] = _getParameterNames
   override def getParameterMap: java.util.Map[String, Array[String]] = _getParameterMap
-  override def getParameter(name: String): String = getParameterMap.get(name).headOption.orNull[String]
+  override def getParameter(name: String): String = Option(getParameterMap.get(name)).map(_.headOption.orNull[String]).orNull[String]
   override def getParameterValues(name: String): Array[String] = getParameterMap.get(name)
 
   override def getRequestDispatcher(path: String): RequestDispatcher = underlying.getRequestDispatcher(path)


### PR DESCRIPTION
`StableHttpServletRequest#getParameter` throws NPE when a request parameter does not exist, contrary to declaration of `ServletRequest#getParameter` as below
> Returns the value of a request parameter as a `String`, or `null` if the parameter does not exist.

so I fixed that to just return `null` when a parameter does not exist.