### PR TITLE
Bump joda-time, slf4j-api

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,13 @@ import sbt.Keys._
 
 import scala.language.postfixOps
 
-lazy val currentVersion = "1.2.0"
+lazy val currentVersion = "1.2.1-SNAPSHOT"
 
 lazy val json4SVersion = "3.5.0"
 lazy val mockitoVersion = "1.10.19"
 lazy val jettyVersion = "9.3.14.v20161028"
 lazy val logbackVersion = "1.1.8"
-lazy val slf4jApiVersion = "1.7.21"
+lazy val slf4jApiVersion = "1.7.22"
 lazy val jacksonVersion = "2.8.5"
 lazy val jacksonScalaVersion = "2.8.4"
 lazy val scalaTestVersion = "3.0.1"
@@ -38,11 +38,8 @@ lazy val baseSettings = Seq(
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature"),
   scalacOptions in (Compile, doc) ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v <= 11 =>
-        Nil
-      case _ =>
-        // https://issues.scala-lang.org/browse/SI-10020
-        Seq("-no-java-comments")
+      case Some((2, v)) if v <= 11 => Nil
+      case _ => Seq("-no-java-comments") // https://issues.scala-lang.org/browse/SI-10020
     }
   },
   publishArtifact in Test := false,
@@ -135,7 +132,7 @@ lazy val microJacksonXml = (project in file("micro-jackson-xml")).settings(baseS
 lazy val microJson4s = (project in file("micro-json4s")).settings(baseSettings ++ mimaSettings ++ Seq(
   name := "skinny-micro-json4s",
   libraryDependencies ++= servletApiDependencies ++ json4sDependencies ++ Seq(
-    "joda-time"         %  "joda-time"          % "2.9.5"                         % Compile,
+    "joda-time"         %  "joda-time"          % "2.9.6"                         % Compile,
     "org.joda"          %  "joda-convert"       % "1.8.1"                         % Compile,
     "com.typesafe.akka" %% "akka-actor"         % akkaVersion(scalaVersion.value) % Test,
     "ch.qos.logback"    %  "logback-classic"    % logbackVersion                  % Test
@@ -191,7 +188,8 @@ lazy val microTest = (project in file("micro-test")).settings(baseSettings ++ mi
 
 lazy val samples = (project in file("samples")).settings(baseSettings ++ Seq(
   libraryDependencies ++= Seq(
-    // "com.typesafe.slick" %% "slick"            % "3.1.1",
+    // Slick dropped Scala 2.10 support
+    //"com.typesafe.slick" %% "slick"            % "3.2.0-M2",
     "org.slf4j"          %  "slf4j-nop"        % slf4jApiVersion,
     "com.h2database"     %  "h2"               % "1.4.193",
     "ch.qos.logback"     %  "logback-classic"  % logbackVersion

--- a/samples/src/main/scala/sample/async_native/ReactiveSlickApp.scala
+++ b/samples/src/main/scala/sample/async_native/ReactiveSlickApp.scala
@@ -1,55 +1,57 @@
-// package sample.async_native
-//
-// import skinny.micro._
-// import skinny.micro.contrib.jackson.JSONSupport
-// import slick.dbio.Effect.{ Schema, Write }
-// import slick.driver.H2Driver
-//
-// import scala.concurrent._
-// import scala.concurrent.duration._
-//
-// import slick.driver.H2Driver.api._
-//
-// class ReactiveSlickApp extends TypedAsyncWebApp with JSONSupport {
-//
-//   lazy val db: H2Driver.backend.DatabaseDef = Database.forConfig("h2mem1")
-//   lazy val suppliers: TableQuery[Suppliers] = TableQuery[Suppliers]
-//   lazy val coffees: TableQuery[Coffees] = TableQuery[Coffees]
-//
-//   before() { implicit ctx =>
-//     contentType = "application/json"
-//   }
-//   error {
-//     case e =>
-//       e.printStackTrace
-//       throw e
-//   }
-//
-//   get("/slick-demo/suppliers") { implicit ctx =>
-//     db.run(suppliers.result).map { ss =>
-//       Ok(toJSONString(ss))
-//     }
-//   }
-//   get("/slick-demo/coffees") { implicit ctx =>
-//     db.run(coffees.filter(_.price > 9.0).result).map { cs =>
-//       Ok(toJSONString(cs))
-//     }
-//   }
-//
-//   val setupAction: DBIOAction[Unit, NoStream, Write with Schema] = DBIO.seq(
-//     (suppliers.schema ++ coffees.schema).create,
-//     suppliers += (101, "Acme, Inc.", "99 Market Street", "Groundsville", "CA", "95199"),
-//     suppliers += (49, "Superior Coffee", "1 Party Place", "Mendocino", "CA", "95460"),
-//     suppliers += (150, "The High Ground", "100 Coffee Lane", "Meadows", "CA", "93966"),
-//     coffees ++= Seq(
-//       ("Colombian", 101, 7.99, 0, 0),
-//       ("French_Roast", 49, 8.99, 0, 0),
-//       ("Espresso", 150, 9.99, 0, 0),
-//       ("Colombian_Decaf", 101, 8.99, 0, 0),
-//       ("French_Roast_Decaf", 49, 9.99, 0, 0)
-//     )
-//   )
-//   val dbFuture: Future[Unit] = db.run(setupAction)
-//   Await.result(dbFuture, 3.seconds)
-//
-// }
+/*
+package sample.async_native
+
+import skinny.micro._
+import skinny.micro.contrib.jackson.JSONSupport
+import slick.dbio.Effect.{ Schema, Write }
+import slick.jdbc.H2Profile
+
+import scala.concurrent._
+import scala.concurrent.duration._
+
+import slick.jdbc.H2Profile.api._
+
+class ReactiveSlickApp extends TypedAsyncWebApp with JSONSupport {
+
+  lazy val db: H2Profile.backend.DatabaseDef = Database.forConfig("h2mem1")
+  lazy val suppliers: TableQuery[Suppliers] = TableQuery[Suppliers]
+  lazy val coffees: TableQuery[Coffees] = TableQuery[Coffees]
+
+  before() { implicit ctx =>
+    contentType = "application/json"
+  }
+  error {
+    case e =>
+      e.printStackTrace
+      throw e
+  }
+
+  get("/slick-demo/suppliers") { implicit ctx =>
+    db.run(suppliers.result).map { ss =>
+      Ok(toJSONString(ss))
+    }
+  }
+  get("/slick-demo/coffees") { implicit ctx =>
+    db.run(coffees.filter(_.price > 9.0).result).map { cs =>
+      Ok(toJSONString(cs))
+    }
+  }
+
+  val setupAction: DBIOAction[Unit, NoStream, Write with Schema] = DBIO.seq(
+    (suppliers.schema ++ coffees.schema).create,
+    suppliers += (101, "Acme, Inc.", "99 Market Street", "Groundsville", "CA", "95199"),
+    suppliers += (49, "Superior Coffee", "1 Party Place", "Mendocino", "CA", "95460"),
+    suppliers += (150, "The High Ground", "100 Coffee Lane", "Meadows", "CA", "93966"),
+    coffees ++= Seq(
+      ("Colombian", 101, 7.99, 0, 0),
+      ("French_Roast", 49, 8.99, 0, 0),
+      ("Espresso", 150, 9.99, 0, 0),
+      ("Colombian_Decaf", 101, 8.99, 0, 0),
+      ("French_Roast_Decaf", 49, 9.99, 0, 0)
+    )
+  )
+  val dbFuture: Future[Unit] = db.run(setupAction)
+  Await.result(dbFuture, 3.seconds)
+
+}
+*/

--- a/samples/src/main/scala/sample/async_native/Tables.scala
+++ b/samples/src/main/scala/sample/async_native/Tables.scala
@@ -1,39 +1,41 @@
-// package sample.async_native
-//
-// import slick.driver.H2Driver.api._
-// import slick.lifted.{ ProvenShape, ForeignKeyQuery }
-//
-// // A Suppliers table with 6 columns: id, name, street, city, state, zip
-// class Suppliers(tag: Tag)
-//     extends Table[(Int, String, String, String, String, String)](tag, "SUPPLIERS") {
-//
-//   // This is the primary key column:
-//   def id: Rep[Int] = column[Int]("SUP_ID", O.PrimaryKey)
-//   def name: Rep[String] = column[String]("SUP_NAME")
-//   def street: Rep[String] = column[String]("STREET")
-//   def city: Rep[String] = column[String]("CITY")
-//   def state: Rep[String] = column[String]("STATE")
-//   def zip: Rep[String] = column[String]("ZIP")
-//
-//   // Every table needs a * projection with the same type as the table's type parameter
-//   def * : ProvenShape[(Int, String, String, String, String, String)] =
-//     (id, name, street, city, state, zip)
-// }
-//
-// // A Coffees table with 5 columns: name, supplier id, price, sales, total
-// class Coffees(tag: Tag)
-//     extends Table[(String, Int, Double, Int, Int)](tag, "COFFEES") {
-//
-//   def name: Rep[String] = column[String]("COF_NAME", O.PrimaryKey)
-//   def supID: Rep[Int] = column[Int]("SUP_ID")
-//   def price: Rep[Double] = column[Double]("PRICE")
-//   def sales: Rep[Int] = column[Int]("SALES")
-//   def total: Rep[Int] = column[Int]("TOTAL")
-//
-//   def * : ProvenShape[(String, Int, Double, Int, Int)] =
-//     (name, supID, price, sales, total)
-//
-//   // A reified foreign key relation that can be navigated to create a join
-//   def supplier: ForeignKeyQuery[Suppliers, (Int, String, String, String, String, String)] =
-//     foreignKey("SUP_FK", supID, TableQuery[Suppliers])(_.id)
-// }
+/*
+package sample.async_native
+
+import slick.jdbc.H2Profile.api._
+import slick.lifted.{ ProvenShape, ForeignKeyQuery }
+
+// A Suppliers table with 6 columns: id, name, street, city, state, zip
+class Suppliers(tag: Tag)
+    extends Table[(Int, String, String, String, String, String)](tag, "SUPPLIERS") {
+
+  // This is the primary key column:
+  def id: Rep[Int] = column[Int]("SUP_ID", O.PrimaryKey)
+  def name: Rep[String] = column[String]("SUP_NAME")
+  def street: Rep[String] = column[String]("STREET")
+  def city: Rep[String] = column[String]("CITY")
+  def state: Rep[String] = column[String]("STATE")
+  def zip: Rep[String] = column[String]("ZIP")
+
+  // Every table needs a * projection with the same type as the table's type parameter
+  def * : ProvenShape[(Int, String, String, String, String, String)] =
+    (id, name, street, city, state, zip)
+}
+
+// A Coffees table with 5 columns: name, supplier id, price, sales, total
+class Coffees(tag: Tag)
+    extends Table[(String, Int, Double, Int, Int)](tag, "COFFEES") {
+
+  def name: Rep[String] = column[String]("COF_NAME", O.PrimaryKey)
+  def supID: Rep[Int] = column[Int]("SUP_ID")
+  def price: Rep[Double] = column[Double]("PRICE")
+  def sales: Rep[Int] = column[Int]("SALES")
+  def total: Rep[Int] = column[Int]("TOTAL")
+
+  def * : ProvenShape[(String, Int, Double, Int, Int)] =
+    (name, supID, price, sales, total)
+
+  // A reified foreign key relation that can be navigated to create a join
+  def supplier: ForeignKeyQuery[Suppliers, (Int, String, String, String, String, String)] =
+    foreignKey("SUP_FK", supID, TableQuery[Suppliers])(_.id)
+}
+ */


### PR DESCRIPTION
This pull request bumps patch version of the following dependencies:

- joda-time
- slf4j

I also tried to re-enable a sample using Slick. But I've gave up it because Slick 3.2 dropped Scala 2.10 support.