### PR TITLE
use Manifest#runtimeClass instead of erasure

### DIFF
--- a/scalatra-test/src/main/scala/org/scalatra/util/conversion/conversions.scala
+++ b/scalatra-test/src/main/scala/org/scalatra/util/conversion/conversions.scala
@@ -29,7 +29,7 @@ object TypeConverterSupport extends TypeConverterSupport
 
 trait LowestPriorityImplicitConversions extends TypeConverterSupport {
   implicit def lowestPriorityAny2T[T: Manifest]: TypeConverter[Any, T] = safe {
-    case a if manifest[T].erasure.isAssignableFrom(a.getClass) => a.asInstanceOf[T]
+    case a if manifest[T].runtimeClass.isAssignableFrom(a.getClass) => a.asInstanceOf[T]
   }
 }
 


### PR DESCRIPTION
erasure is deprecated

https://github.com/scala/scala/blob/v2.11.12/src/library/scala/reflect/ClassManifestDeprecatedApis.scala#L20-L21