### PR TITLE
fix "assignments in argument position" warning

### DIFF
--- a/scalatra-test/src/main/scala/org/scalatra/ScalatraBase.scala
+++ b/scalatra-test/src/main/scala/org/scalatra/ScalatraBase.scala
@@ -173,7 +173,7 @@ trait ScalatraBase extends ScalatraContext with CoreDsl with DynamicScope with I
       }
     }
 
-    cradleHalt(result = runActions, e => {
+    cradleHalt({ result = runActions }, e => {
       cradleHalt({
         result = errorHandler(e)
         rendered = false


### PR DESCRIPTION
https://github.com/scala/scala/commit/8272151ac87628e2f1165547ff4b794f3226bbbc

```
[warn] /home/travis/build/skinny-framework/skinny-micro/scalatra-test/src/main/scala/org/scalatra/ScalatraBase.scala:176: assignments in argument position are deprecated in favor of named arguments. Wrap the assignment in brackets, e.g., `{ result = ... }`.
[warn]     cradleHalt(result = runActions, e => {
[warn]                       ^
```