### PR TITLE
avoid deprecated Double Range

### DIFF
--- a/micro/src/main/scala/skinny/micro/ApiFormats.scala
+++ b/micro/src/main/scala/skinny/micro/ApiFormats.scala
@@ -116,9 +116,11 @@ trait ApiFormats extends SkinnyMicroBase with RicherStringImplicits {
     response.contentType flatMap (ctt => ctt.split(";").headOption flatMap mimeTypes.get)
   }
 
+  private[this] val validRange: Set[Double] =
+    Set(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
+
   private def parseAcceptHeader(implicit request: HttpServletRequest): List[String] = {
     def isValidQPair(a: Array[String]) = {
-      val validRange = Range.Double.inclusive(0, 1, 0.1)
       a.length == 2 && a(0) == "q" && validRange.contains(a(1).toDouble)
     }
 

--- a/scalatra-test/src/main/scala/org/scalatra/ApiFormats.scala
+++ b/scalatra-test/src/main/scala/org/scalatra/ApiFormats.scala
@@ -113,9 +113,11 @@ trait ApiFormats extends ScalatraBase {
     response.contentType flatMap (ctt => ctt.split(";").headOption flatMap mimeTypes.get)
   }
 
+  private[this] val validRange: Set[Double] =
+    Set(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
+
   private def parseAcceptHeader(implicit request: HttpServletRequest): List[String] = {
     def isValidQPair(a: Array[String]) = {
-      val validRange = Range.Double.inclusive(0, 1, 0.1)
       a.length == 2 && a(0) == "q" && validRange.contains(a(1).toDouble)
     }
 


### PR DESCRIPTION
deprecated since 2.12.6. removed since Scala 2.13

- https://github.com/scala/scala/commit/340b899536f767ccb6fc49d13879cdcacab3999d
- https://github.com/scala/scala/commit/16f58a13eeea78ebac98440d44667cf23a1a