### PR TITLE
Remove akka-actor from test dependencies in order to support Scala 2.13.0-M4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ lazy val slf4jApiVersion = "1.7.25"
 lazy val jacksonVersion = "2.9.6"
 lazy val jacksonScalaVersion = "2.9.6"
 lazy val scalaTestVersion = "3.0.5"
-lazy val akkaVersion = "2.5.14"
 lazy val collectionCompatVersion = "0.1.1"
 
 lazy val baseSettings = Seq(
@@ -99,8 +98,7 @@ lazy val micro = (project in file("micro")).settings(baseSettings ++ mimaSetting
   libraryDependencies ++= {
     servletApiDependencies ++ slf4jApiDependencies ++ Seq(
       "com.googlecode.juniversalchardet" %  "juniversalchardet" % "1.0.3" % Compile,
-      "ch.qos.logback"    %  "logback-classic" % logbackVersion           % Test,
-      "com.typesafe.akka" %% "akka-actor"      % akkaVersion              % Test
+      "ch.qos.logback"    %  "logback-classic" % logbackVersion           % Test
     ) ++ (scalaVersion.value match {
       case v if v.startsWith("2.11.")
              || v.startsWith("2.12.") =>
@@ -113,7 +111,6 @@ lazy val micro = (project in file("micro")).settings(baseSettings ++ mimaSetting
 lazy val microJackson = (project in file("micro-jackson")).settings(baseSettings ++ mimaSettings ++ Seq(
   name := "skinny-micro-jackson",
   libraryDependencies ++= servletApiDependencies ++ jacksonDependencies ++ Seq(
-    "com.typesafe.akka" %% "akka-actor"         % akkaVersion    % Test,
     "ch.qos.logback"    %  "logback-classic"    % logbackVersion % Test
   )
 )).dependsOn(micro, scalatraTest % Test)
@@ -123,7 +120,6 @@ lazy val microJacksonXml = (project in file("micro-jackson-xml")).settings(baseS
   libraryDependencies ++= servletApiDependencies ++ jacksonDependencies ++ Seq(
     "com.fasterxml.jackson.dataformat" %  "jackson-dataformat-xml" % jacksonVersion % Compile,
     "org.codehaus.woodstox"            %  "woodstox-core-asl"      % "4.4.1"        % Compile,
-    "com.typesafe.akka"                %% "akka-actor"             % akkaVersion    % Test,
     "ch.qos.logback"                   %  "logback-classic"        % logbackVersion % Test
   )
 )).dependsOn(micro, microJackson, scalatraTest % Test)
@@ -133,7 +129,6 @@ lazy val microJson4s = (project in file("micro-json4s")).settings(baseSettings +
   libraryDependencies ++= servletApiDependencies ++ json4sDependencies ++ Seq(
     "joda-time"         %  "joda-time"          % "2.10"         % Compile,
     "org.joda"          %  "joda-convert"       % "2.1.1"        % Compile,
-    "com.typesafe.akka" %% "akka-actor"         % akkaVersion    % Test,
     "ch.qos.logback"    %  "logback-classic"    % logbackVersion % Test
   )
 )).dependsOn(micro, scalatraTest % Test)
@@ -142,7 +137,6 @@ lazy val microScalate = (project in file("micro-scalate")).settings(baseSettings
   name := "skinny-micro-scalate",
   libraryDependencies ++= slf4jApiDependencies ++ servletApiDependencies ++ Seq(
     "org.scalatra.scalate"  %% "scalate-core"       % "1.9.0"        % Compile excludeAll(fullExclusionRules: _*),
-    "com.typesafe.akka"     %% "akka-actor"         % akkaVersion    % Test,
     "ch.qos.logback"        %  "logback-classic"    % logbackVersion % Test
   )
 )).dependsOn(micro, scalatraTest % Test)

--- a/micro/src/test/scala/scalatra_compatible/FutureSupportAfterFilterForFiltersSpec.scala
+++ b/micro/src/test/scala/scalatra_compatible/FutureSupportAfterFilterForFiltersSpec.scala
@@ -1,17 +1,15 @@
 package scalatra_compatible
 
-import _root_.akka.actor.ActorSystem
 import org.scalatra.test.specs2.MutableScalatraSpec
 import skinny.micro.SkinnyMicroFilter
 
 import scala.concurrent.Future
 
 class FutureSupportAfterFilterFilter extends SkinnyMicroFilter {
-  val system = ActorSystem()
   var actionTime: Long = _
   var afterTime: Long = _
   var afterCount: Long = _
-  protected override implicit lazy val executionContext = system.dispatcher
+  protected override implicit lazy val executionContext = scala.concurrent.ExecutionContext.global
 
   get("/async") {
     Thread.sleep(2000)
@@ -49,11 +47,6 @@ class FutureSupportAfterFilterFilter extends SkinnyMicroFilter {
     actionTime = 0L
     afterTime = 0L
     afterCount = 0L
-  }
-
-  override def destroy(): Unit = {
-    super.destroy()
-    system.terminate()
   }
 }
 

--- a/micro/src/test/scala/scalatra_compatible/FutureSupportAfterFilterSpec.scala
+++ b/micro/src/test/scala/scalatra_compatible/FutureSupportAfterFilterSpec.scala
@@ -1,17 +1,15 @@
 package scalatra_compatible
 
-import _root_.akka.actor.ActorSystem
 import org.scalatra.test.specs2.MutableScalatraSpec
 import skinny.micro.SkinnyMicroServlet
 
 import scala.concurrent.Future
 
 class FutureSupportAfterFilterServlet extends SkinnyMicroServlet {
-  val system = ActorSystem()
   var actionTime: Long = _
   var afterTime: Long = _
   var afterCount: Long = _
-  protected override implicit val executionContext = system.dispatcher
+  protected override implicit val executionContext = scala.concurrent.ExecutionContext.global
 
   get("/async") {
     Thread.sleep(2000)
@@ -53,7 +51,6 @@ class FutureSupportAfterFilterServlet extends SkinnyMicroServlet {
 
   override def destroy(): Unit = {
     super.destroy()
-    system.terminate()
   }
 }
 


### PR DESCRIPTION
The existing test suites using akka-actor is no longer so important that I decided to get rid of the dependency to release new versions more smoothly.