### PR TITLE
Add BaseConfigType to ThinServletBaseConfig to distinguish whether servlet or filter

### DIFF
--- a/micro/src/main/scala/skinny/micro/SkinnyMicroFilterBase.scala
+++ b/micro/src/main/scala/skinny/micro/SkinnyMicroFilterBase.scala
@@ -73,14 +73,14 @@ trait SkinnyMicroFilterBase extends SkinnyMicroBase {
     filterChain.doFilter(request, response)
   }
 
-  type ConfigT = FilterConfig
-
   // see Initializable.initialize for why
   def init(filterConfig: FilterConfig): Unit = {
     initialize(new ThinServletBaseConfig {
       override def getServletContext(): ServletContext = filterConfig.getServletContext
       override def getInitParameter(name: String): String = filterConfig.getInitParameter(name)
       override def getInitParameterNames(): java.util.Enumeration[String] = filterConfig.getInitParameterNames
+      override def getBaseConfigType: BaseConfigType = BaseConfigType.FilterConfig
+      override def getFilterConfig: Option[FilterConfig] = Some(filterConfig)
     })
   }
 

--- a/micro/src/main/scala/skinny/micro/SkinnyMicroServletBase.scala
+++ b/micro/src/main/scala/skinny/micro/SkinnyMicroServletBase.scala
@@ -87,14 +87,14 @@ trait SkinnyMicroServletBase extends HttpServlet with SkinnyMicroBase {
     }
   }
 
-  type ConfigT = ServletConfig
-
   override def init(config: ServletConfig): Unit = {
     super.init(config)
     initialize(new ThinServletBaseConfig {
       override def getServletContext(): ServletContext = config.getServletContext
       override def getInitParameter(name: String): String = config.getInitParameter(name)
       override def getInitParameterNames(): java.util.Enumeration[String] = config.getInitParameterNames
+      override def getBaseConfigType: BaseConfigType = BaseConfigType.ServletConfig
+      override def getServletConfig: Option[ServletConfig] = Some(config)
     }) // see Initializable.initialize for why
   }
 

--- a/micro/src/main/scala/skinny/micro/base/ServletContextAccessor.scala
+++ b/micro/src/main/scala/skinny/micro/base/ServletContextAccessor.scala
@@ -18,12 +18,11 @@ trait ServletContextAccessor
 
   import SkinnyMicroBase._
 
-  private trait NullConfig extends ThinServletBaseConfig with FilterConfig {
-    def getServletName: String = null
-    override def getFilterName: String = null
+  private class NullConfig extends ThinServletBaseConfig {
     override def getServletContext(): ServletContext = null
     override def getInitParameter(name: String): String = null
     override def getInitParameterNames(): java.util.Enumeration[String] = null
+    override def getBaseConfigType: BaseConfigType = BaseConfigType.Unknown
   }
 
   protected implicit def configWrapper(config: ThinServletBaseConfig) = new Config {

--- a/micro/src/main/scala/skinny/micro/context/RichServletContext.scala
+++ b/micro/src/main/scala/skinny/micro/context/RichServletContext.scala
@@ -200,6 +200,7 @@ case class RichServletContext(sc: ServletContext) extends AttributesMap {
     override def getServletContext(): ServletContext = attributes
     override def getInitParameter(name: String): String = attributes.getInitParameter(name)
     override def getInitParameterNames(): java.util.Enumeration[String] = attributes.getInitParameterNames
+    override def getBaseConfigType: BaseConfigType = BaseConfigType.Unknown
   })
 
   def contextPath: String = sc.getContextPath

--- a/micro/src/main/scala/skinny/micro/context/ThinServletBaseConfig.scala
+++ b/micro/src/main/scala/skinny/micro/context/ThinServletBaseConfig.scala
@@ -1,13 +1,27 @@
 package skinny.micro.context
 
-import javax.servlet.ServletContext
+import javax.servlet.{ FilterConfig, ServletConfig, ServletContext }
 
 trait ThinServletBaseConfig {
+
+  sealed trait BaseConfigType
+
+  object BaseConfigType {
+    case object Unknown extends BaseConfigType
+    case object ServletConfig extends BaseConfigType
+    case object FilterConfig extends BaseConfigType
+  }
 
   def getServletContext(): ServletContext
 
   def getInitParameter(name: String): String
 
   def getInitParameterNames(): java.util.Enumeration[String]
+
+  def getBaseConfigType: BaseConfigType
+
+  def getServletConfig: Option[ServletConfig] = None
+
+  def getFilterConfig: Option[FilterConfig] = None
 
 }


### PR DESCRIPTION
Since version 1.4.0-RC3, I changed the internal of skinny-micro to switch from ConfigT type to ThinServletBaseConfig. Afterward, I noticed that a portion of code in skinny-framework depends on the type (there is a pattern matching code which checks its actual type is ServletConfig or FilterConfig). This pull request adds #getBaseConfigType to test the type in a proper way and also adds accessors to ServletConfig / FilterConfig.