### PR TITLE
Re-fix #59 by having ThinServletBaseConfig.BaseConfigType.* in compaion object

### DIFF
--- a/micro-scalate/src/main/scala/skinny/micro/contrib/ScalateSupport.scala
+++ b/micro-scalate/src/main/scala/skinny/micro/contrib/ScalateSupport.scala
@@ -2,8 +2,8 @@ package skinny.micro.contrib
 
 import java.io.{ PrintWriter, StringWriter }
 
-import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 import javax.servlet.{ FilterConfig, ServletConfig }
+import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 import org.fusesource.scalate.layout.DefaultLayoutStrategy
 import org.fusesource.scalate.servlet.ServletTemplateEngine
 import org.fusesource.scalate.support.TemplateFinder
@@ -57,13 +57,23 @@ trait ScalateSupport extends SkinnyMicroBase {
       case "" => "ROOT"
       case path => path.substring(1)
     }
-    config match {
-      case filterConfig: FilterConfig =>
-        val templateEngine = new ServletTemplateEngine(filterConfig) with SkinnyMicroTemplateEngine
-        ScalateSupport.scalateTemplateEngine(contextPath, templateEngine)
-      case servletConfig: ServletConfig =>
-        val templateEngine = new ServletTemplateEngine(servletConfig) with SkinnyMicroTemplateEngine
-        ScalateSupport.scalateTemplateEngine(contextPath, templateEngine)
+    config.getBaseConfigType match {
+      case ThinServletBaseConfig.BaseConfigType.FilterConfig =>
+        config.getFilterConfig match {
+          case Some(filterConfig: FilterConfig) =>
+            val templateEngine = new ServletTemplateEngine(filterConfig) with SkinnyMicroTemplateEngine
+            ScalateSupport.scalateTemplateEngine(contextPath, templateEngine)
+          case _ => throw new IllegalStateException(
+            "ThinServletBaseConfig#getFilterConfig should return a Some value when BaseConfigType is FilterConfig")
+        }
+      case ThinServletBaseConfig.BaseConfigType.ServletConfig =>
+        config.getServletConfig match {
+          case Some(servletConfig: ServletConfig) =>
+            val templateEngine = new ServletTemplateEngine(servletConfig) with SkinnyMicroTemplateEngine
+            ScalateSupport.scalateTemplateEngine(contextPath, templateEngine)
+          case _ => throw new IllegalStateException(
+            "ThinServletBaseConfig#getServletConfig should return a Some value when BaseConfigType is ServletConfig")
+        }
       case _ =>
         // Don't know how to convert your Config to something that
         // ServletTemplateEngine can accept, so fall back to a TemplateEngine

--- a/micro/src/main/scala/skinny/micro/SkinnyMicroFilterBase.scala
+++ b/micro/src/main/scala/skinny/micro/SkinnyMicroFilterBase.scala
@@ -2,6 +2,7 @@ package skinny.micro
 
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 import javax.servlet._
+import skinny.micro.context.ThinServletBaseConfig.BaseConfigType
 import skinny.micro.context.{ SkinnyContext, ThinServletBaseConfig }
 import skinny.micro.util.UriDecoder
 

--- a/micro/src/main/scala/skinny/micro/SkinnyMicroServletBase.scala
+++ b/micro/src/main/scala/skinny/micro/SkinnyMicroServletBase.scala
@@ -2,6 +2,7 @@ package skinny.micro
 
 import javax.servlet.http.{ HttpServlet, HttpServletRequest, HttpServletResponse }
 import javax.servlet._
+import skinny.micro.context.ThinServletBaseConfig.BaseConfigType
 import skinny.micro.context.{ SkinnyContext, ThinServletBaseConfig }
 import skinny.micro.implicits.{ RicherStringImplicits, ServletApiImplicits }
 import skinny.micro.util.UriDecoder

--- a/micro/src/main/scala/skinny/micro/base/ServletContextAccessor.scala
+++ b/micro/src/main/scala/skinny/micro/base/ServletContextAccessor.scala
@@ -3,6 +3,7 @@ package skinny.micro.base
 import scala.language.reflectiveCalls
 import scala.language.implicitConversions
 import javax.servlet.{ FilterConfig, ServletContext }
+import skinny.micro.context.ThinServletBaseConfig.BaseConfigType
 import skinny.micro.implicits.{ RicherStringImplicits, ServletApiImplicits }
 import skinny.micro.{ Initializable, SkinnyMicroBase }
 import skinny.micro.context.{ InitParameters, SkinnyContext, ThinServletBaseConfig }

--- a/micro/src/main/scala/skinny/micro/context/RichServletContext.scala
+++ b/micro/src/main/scala/skinny/micro/context/RichServletContext.scala
@@ -7,6 +7,7 @@ import javax.servlet.http.{ HttpServlet, HttpServletRequest }
 import javax.servlet.{ DispatcherType, Filter, ServletContext, ServletRegistration }
 import skinny.micro._
 import skinny.micro.async.AsyncSupported
+import skinny.micro.context.ThinServletBaseConfig.BaseConfigType
 import skinny.micro.data.AttributesMap
 import skinny.micro.multipart.HasMultipartConfig
 

--- a/micro/src/main/scala/skinny/micro/context/ThinServletBaseConfig.scala
+++ b/micro/src/main/scala/skinny/micro/context/ThinServletBaseConfig.scala
@@ -2,7 +2,7 @@ package skinny.micro.context
 
 import javax.servlet.{ FilterConfig, ServletConfig, ServletContext }
 
-trait ThinServletBaseConfig {
+object ThinServletBaseConfig {
 
   sealed trait BaseConfigType
 
@@ -12,13 +12,17 @@ trait ThinServletBaseConfig {
     case object FilterConfig extends BaseConfigType
   }
 
+}
+
+trait ThinServletBaseConfig {
+
   def getServletContext(): ServletContext
 
   def getInitParameter(name: String): String
 
   def getInitParameterNames(): java.util.Enumeration[String]
 
-  def getBaseConfigType: BaseConfigType
+  def getBaseConfigType: ThinServletBaseConfig.BaseConfigType
 
   def getServletConfig: Option[ServletConfig] = None
 


### PR DESCRIPTION
Mistakenly, I put the objects in the trait. This pull request adds the companion for it and moved internal objects to the companion.