### PR TITLE
use xenial and openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ scala:
   - 2.12.8
   - 2.13.0
 jdk:
-  - oraclejdk8
+  - openjdk8
+dist: xenial
 matrix:
   include:
   - scala: 2.12.8
-    jdk: oraclejdk9
+    jdk: openjdk9
   - scala: 2.12.8
     jdk: openjdk11
 cache:


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-08-xenial-release
https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802

> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.